### PR TITLE
add SDK support for all attestation intrinsics arbiters

### DIFF
--- a/src/clients/arbiters.ts
+++ b/src/clients/arbiters.ts
@@ -21,6 +21,7 @@ export const makeArbitersClient = (
 
   return {
     /**
+     * @deprecated Use makeLogicalArbitersClient().encodeAnyArbiterDemand or encodeAllArbiterDemand instead
      * Encodes AnyArbiter.DemandData or AllArbiter.DemandData to bytes.
      * @param demand - struct DemandData {address[] arbiters, bytes[] demands}
      * @returns abi encoded bytes
@@ -36,6 +37,7 @@ export const makeArbitersClient = (
     },
 
     /**
+     * @deprecated Use makeLogicalArbitersClient().decodeAnyArbiterDemand or decodeAllArbiterDemand instead
      * Decodes AnyArbiter.DemandData or AllArbiter.DemandData from bytes.
      * @param demandData - DemandData as abi encoded bytes
      * @returns the decoded DemandData object

--- a/src/clients/attestationPropertiesArbiters.ts
+++ b/src/clients/attestationPropertiesArbiters.ts
@@ -1,0 +1,562 @@
+import {
+  decodeAbiParameters,
+  encodeAbiParameters,
+  parseAbiParameters,
+} from "viem";
+import type { ViemClient } from "../utils";
+import type { ChainAddresses } from "../types";
+
+export const makeAttestationPropertiesArbitersClient = (
+  viemClient: ViemClient,
+  addresses: ChainAddresses,
+) => {
+  return {
+    /**
+     * Encodes AttesterArbiterComposing.DemandData to bytes.
+     * @param demand - struct DemandData {address baseArbiter, bytes baseDemand, address expectedAttester}
+     * @returns abi encoded bytes
+     */
+    encodeAttesterArbiterComposingDemand: (demand: {
+      baseArbiter: `0x${string}`;
+      baseDemand: `0x${string}`;
+      expectedAttester: `0x${string}`;
+    }) => {
+      return encodeAbiParameters(
+        parseAbiParameters("(address baseArbiter, bytes baseDemand, address expectedAttester)"),
+        [demand],
+      );
+    },
+
+    /**
+     * Decodes AttesterArbiterComposing.DemandData from bytes.
+     * @param demandData - DemandData as abi encoded bytes
+     * @returns the decoded DemandData object
+     */
+    decodeAttesterArbiterComposingDemand: (demandData: `0x${string}`) => {
+      return decodeAbiParameters(
+        parseAbiParameters("(address baseArbiter, bytes baseDemand, address expectedAttester)"),
+        demandData,
+      )[0];
+    },
+
+    /**
+     * Encodes AttesterArbiterNonComposing.DemandData to bytes.
+     * @param demand - struct DemandData {address expectedAttester}
+     * @returns abi encoded bytes
+     */
+    encodeAttesterArbiterNonComposingDemand: (demand: {
+      expectedAttester: `0x${string}`;
+    }) => {
+      return encodeAbiParameters(
+        parseAbiParameters("(address expectedAttester)"),
+        [demand],
+      );
+    },
+
+    /**
+     * Decodes AttesterArbiterNonComposing.DemandData from bytes.
+     * @param demandData - DemandData as abi encoded bytes
+     * @returns the decoded DemandData object
+     */
+    decodeAttesterArbiterNonComposingDemand: (demandData: `0x${string}`) => {
+      return decodeAbiParameters(
+        parseAbiParameters("(address expectedAttester)"),
+        demandData,
+      )[0];
+    },
+
+    /**
+     * Encodes ExpirationTimeArbiterComposing.DemandData to bytes.
+     * @param demand - struct DemandData {address baseArbiter, bytes baseDemand, uint64 minExpirationTime, uint64 maxExpirationTime}
+     * @returns abi encoded bytes
+     */
+    encodeExpirationTimeArbiterComposingDemand: (demand: {
+      baseArbiter: `0x${string}`;
+      baseDemand: `0x${string}`;
+      minExpirationTime: bigint;
+      maxExpirationTime: bigint;
+    }) => {
+      return encodeAbiParameters(
+        parseAbiParameters("(address baseArbiter, bytes baseDemand, uint64 minExpirationTime, uint64 maxExpirationTime)"),
+        [demand],
+      );
+    },
+
+    /**
+     * Decodes ExpirationTimeArbiterComposing.DemandData from bytes.
+     * @param demandData - DemandData as abi encoded bytes
+     * @returns the decoded DemandData object
+     */
+    decodeExpirationTimeArbiterComposingDemand: (demandData: `0x${string}`) => {
+      return decodeAbiParameters(
+        parseAbiParameters("(address baseArbiter, bytes baseDemand, uint64 minExpirationTime, uint64 maxExpirationTime)"),
+        demandData,
+      )[0];
+    },
+
+    /**
+     * Encodes ExpirationTimeArbiterNonComposing.DemandData to bytes.
+     * @param demand - struct DemandData {uint64 minExpirationTime, uint64 maxExpirationTime}
+     * @returns abi encoded bytes
+     */
+    encodeExpirationTimeArbiterNonComposingDemand: (demand: {
+      minExpirationTime: bigint;
+      maxExpirationTime: bigint;
+    }) => {
+      return encodeAbiParameters(
+        parseAbiParameters("(uint64 minExpirationTime, uint64 maxExpirationTime)"),
+        [demand],
+      );
+    },
+
+    /**
+     * Decodes ExpirationTimeArbiterNonComposing.DemandData from bytes.
+     * @param demandData - DemandData as abi encoded bytes
+     * @returns the decoded DemandData object
+     */
+    decodeExpirationTimeArbiterNonComposingDemand: (demandData: `0x${string}`) => {
+      return decodeAbiParameters(
+        parseAbiParameters("(uint64 minExpirationTime, uint64 maxExpirationTime)"),
+        demandData,
+      )[0];
+    },
+
+    /**
+     * Encodes RecipientArbiterComposing.DemandData to bytes.
+     * @param demand - struct DemandData {address baseArbiter, bytes baseDemand, address expectedRecipient}
+     * @returns abi encoded bytes
+     */
+    encodeRecipientArbiterComposingDemand: (demand: {
+      baseArbiter: `0x${string}`;
+      baseDemand: `0x${string}`;
+      expectedRecipient: `0x${string}`;
+    }) => {
+      return encodeAbiParameters(
+        parseAbiParameters("(address baseArbiter, bytes baseDemand, address expectedRecipient)"),
+        [demand],
+      );
+    },
+
+    /**
+     * Decodes RecipientArbiterComposing.DemandData from bytes.
+     * @param demandData - DemandData as abi encoded bytes
+     * @returns the decoded DemandData object
+     */
+    decodeRecipientArbiterComposingDemand: (demandData: `0x${string}`) => {
+      return decodeAbiParameters(
+        parseAbiParameters("(address baseArbiter, bytes baseDemand, address expectedRecipient)"),
+        demandData,
+      )[0];
+    },
+
+    /**
+     * Encodes RecipientArbiterNonComposing.DemandData to bytes.
+     * @param demand - struct DemandData {address expectedRecipient}
+     * @returns abi encoded bytes
+     */
+    encodeRecipientArbiterNonComposingDemand: (demand: {
+      expectedRecipient: `0x${string}`;
+    }) => {
+      return encodeAbiParameters(
+        parseAbiParameters("(address expectedRecipient)"),
+        [demand],
+      );
+    },
+
+    /**
+     * Decodes RecipientArbiterNonComposing.DemandData from bytes.
+     * @param demandData - DemandData as abi encoded bytes
+     * @returns the decoded DemandData object
+     */
+    decodeRecipientArbiterNonComposingDemand: (demandData: `0x${string}`) => {
+      return decodeAbiParameters(
+        parseAbiParameters("(address expectedRecipient)"),
+        demandData,
+      )[0];
+    },
+
+    /**
+     * Encodes RefUidArbiterComposing.DemandData to bytes.
+     * @param demand - struct DemandData {address baseArbiter, bytes baseDemand, bytes32 expectedRefUID}
+     * @returns abi encoded bytes
+     */
+    encodeRefUidArbiterComposingDemand: (demand: {
+      baseArbiter: `0x${string}`;
+      baseDemand: `0x${string}`;
+      expectedRefUID: `0x${string}`;
+    }) => {
+      return encodeAbiParameters(
+        parseAbiParameters("(address baseArbiter, bytes baseDemand, bytes32 expectedRefUID)"),
+        [demand],
+      );
+    },
+
+    /**
+     * Decodes RefUidArbiterComposing.DemandData from bytes.
+     * @param demandData - DemandData as abi encoded bytes
+     * @returns the decoded DemandData object
+     */
+    decodeRefUidArbiterComposingDemand: (demandData: `0x${string}`) => {
+      return decodeAbiParameters(
+        parseAbiParameters("(address baseArbiter, bytes baseDemand, bytes32 expectedRefUID)"),
+        demandData,
+      )[0];
+    },
+
+    /**
+     * Encodes RefUidArbiterNonComposing.DemandData to bytes.
+     * @param demand - struct DemandData {bytes32 expectedRefUID}
+     * @returns abi encoded bytes
+     */
+    encodeRefUidArbiterNonComposingDemand: (demand: {
+      expectedRefUID: `0x${string}`;
+    }) => {
+      return encodeAbiParameters(
+        parseAbiParameters("(bytes32 expectedRefUID)"),
+        [demand],
+      );
+    },
+
+    /**
+     * Decodes RefUidArbiterNonComposing.DemandData from bytes.
+     * @param demandData - DemandData as abi encoded bytes
+     * @returns the decoded DemandData object
+     */
+    decodeRefUidArbiterNonComposingDemand: (demandData: `0x${string}`) => {
+      return decodeAbiParameters(
+        parseAbiParameters("(bytes32 expectedRefUID)"),
+        demandData,
+      )[0];
+    },
+
+    /**
+     * Encodes RevocableArbiterComposing.DemandData to bytes.
+     * @param demand - struct DemandData {address baseArbiter, bytes baseDemand, bool expectedRevocable}
+     * @returns abi encoded bytes
+     */
+    encodeRevocableArbiterComposingDemand: (demand: {
+      baseArbiter: `0x${string}`;
+      baseDemand: `0x${string}`;
+      expectedRevocable: boolean;
+    }) => {
+      return encodeAbiParameters(
+        parseAbiParameters("(address baseArbiter, bytes baseDemand, bool expectedRevocable)"),
+        [demand],
+      );
+    },
+
+    /**
+     * Decodes RevocableArbiterComposing.DemandData from bytes.
+     * @param demandData - DemandData as abi encoded bytes
+     * @returns the decoded DemandData object
+     */
+    decodeRevocableArbiterComposingDemand: (demandData: `0x${string}`) => {
+      return decodeAbiParameters(
+        parseAbiParameters("(address baseArbiter, bytes baseDemand, bool expectedRevocable)"),
+        demandData,
+      )[0];
+    },
+
+    /**
+     * Encodes RevocableArbiterNonComposing.DemandData to bytes.
+     * @param demand - struct DemandData {bool expectedRevocable}
+     * @returns abi encoded bytes
+     */
+    encodeRevocableArbiterNonComposingDemand: (demand: {
+      expectedRevocable: boolean;
+    }) => {
+      return encodeAbiParameters(
+        parseAbiParameters("(bool expectedRevocable)"),
+        [demand],
+      );
+    },
+
+    /**
+     * Decodes RevocableArbiterNonComposing.DemandData from bytes.
+     * @param demandData - DemandData as abi encoded bytes
+     * @returns the decoded DemandData object
+     */
+    decodeRevocableArbiterNonComposingDemand: (demandData: `0x${string}`) => {
+      return decodeAbiParameters(
+        parseAbiParameters("(bool expectedRevocable)"),
+        demandData,
+      )[0];
+    },
+
+    /**
+     * Encodes RevocationTimeArbiterComposing.DemandData to bytes.
+     * @param demand - struct DemandData {address baseArbiter, bytes baseDemand, uint64 minRevocationTime, uint64 maxRevocationTime}
+     * @returns abi encoded bytes
+     */
+    encodeRevocationTimeArbiterComposingDemand: (demand: {
+      baseArbiter: `0x${string}`;
+      baseDemand: `0x${string}`;
+      minRevocationTime: bigint;
+      maxRevocationTime: bigint;
+    }) => {
+      return encodeAbiParameters(
+        parseAbiParameters("(address baseArbiter, bytes baseDemand, uint64 minRevocationTime, uint64 maxRevocationTime)"),
+        [demand],
+      );
+    },
+
+    /**
+     * Decodes RevocationTimeArbiterComposing.DemandData from bytes.
+     * @param demandData - DemandData as abi encoded bytes
+     * @returns the decoded DemandData object
+     */
+    decodeRevocationTimeArbiterComposingDemand: (demandData: `0x${string}`) => {
+      return decodeAbiParameters(
+        parseAbiParameters("(address baseArbiter, bytes baseDemand, uint64 minRevocationTime, uint64 maxRevocationTime)"),
+        demandData,
+      )[0];
+    },
+
+    /**
+     * Encodes RevocationTimeArbiterNonComposing.DemandData to bytes.
+     * @param demand - struct DemandData {uint64 minRevocationTime, uint64 maxRevocationTime}
+     * @returns abi encoded bytes
+     */
+    encodeRevocationTimeArbiterNonComposingDemand: (demand: {
+      minRevocationTime: bigint;
+      maxRevocationTime: bigint;
+    }) => {
+      return encodeAbiParameters(
+        parseAbiParameters("(uint64 minRevocationTime, uint64 maxRevocationTime)"),
+        [demand],
+      );
+    },
+
+    /**
+     * Decodes RevocationTimeArbiterNonComposing.DemandData from bytes.
+     * @param demandData - DemandData as abi encoded bytes
+     * @returns the decoded DemandData object
+     */
+    decodeRevocationTimeArbiterNonComposingDemand: (demandData: `0x${string}`) => {
+      return decodeAbiParameters(
+        parseAbiParameters("(uint64 minRevocationTime, uint64 maxRevocationTime)"),
+        demandData,
+      )[0];
+    },
+
+    /**
+     * Encodes SchemaArbiterComposing.DemandData to bytes.
+     * @param demand - struct DemandData {address baseArbiter, bytes baseDemand, bytes32 expectedSchema}
+     * @returns abi encoded bytes
+     */
+    encodeSchemaArbiterComposingDemand: (demand: {
+      baseArbiter: `0x${string}`;
+      baseDemand: `0x${string}`;
+      expectedSchema: `0x${string}`;
+    }) => {
+      return encodeAbiParameters(
+        parseAbiParameters("(address baseArbiter, bytes baseDemand, bytes32 expectedSchema)"),
+        [demand],
+      );
+    },
+
+    /**
+     * Decodes SchemaArbiterComposing.DemandData from bytes.
+     * @param demandData - DemandData as abi encoded bytes
+     * @returns the decoded DemandData object
+     */
+    decodeSchemaArbiterComposingDemand: (demandData: `0x${string}`) => {
+      return decodeAbiParameters(
+        parseAbiParameters("(address baseArbiter, bytes baseDemand, bytes32 expectedSchema)"),
+        demandData,
+      )[0];
+    },
+
+    /**
+     * Encodes SchemaArbiterNonComposing.DemandData to bytes.
+     * @param demand - struct DemandData {bytes32 expectedSchema}
+     * @returns abi encoded bytes
+     */
+    encodeSchemaArbiterNonComposingDemand: (demand: {
+      expectedSchema: `0x${string}`;
+    }) => {
+      return encodeAbiParameters(
+        parseAbiParameters("(bytes32 expectedSchema)"),
+        [demand],
+      );
+    },
+
+    /**
+     * Decodes SchemaArbiterNonComposing.DemandData from bytes.
+     * @param demandData - DemandData as abi encoded bytes
+     * @returns the decoded DemandData object
+     */
+    decodeSchemaArbiterNonComposingDemand: (demandData: `0x${string}`) => {
+      return decodeAbiParameters(
+        parseAbiParameters("(bytes32 expectedSchema)"),
+        demandData,
+      )[0];
+    },
+
+    /**
+     * Encodes TimestampArbiterComposing.DemandData to bytes.
+     * @param demand - struct DemandData {address baseArbiter, bytes baseDemand, uint64 minTimestamp, uint64 maxTimestamp}
+     * @returns abi encoded bytes
+     */
+    encodeTimestampArbiterComposingDemand: (demand: {
+      baseArbiter: `0x${string}`;
+      baseDemand: `0x${string}`;
+      minTimestamp: bigint;
+      maxTimestamp: bigint;
+    }) => {
+      return encodeAbiParameters(
+        parseAbiParameters("(address baseArbiter, bytes baseDemand, uint64 minTimestamp, uint64 maxTimestamp)"),
+        [demand],
+      );
+    },
+
+    /**
+     * Decodes TimestampArbiterComposing.DemandData from bytes.
+     * @param demandData - DemandData as abi encoded bytes
+     * @returns the decoded DemandData object
+     */
+    decodeTimestampArbiterComposingDemand: (demandData: `0x${string}`) => {
+      return decodeAbiParameters(
+        parseAbiParameters("(address baseArbiter, bytes baseDemand, uint64 minTimestamp, uint64 maxTimestamp)"),
+        demandData,
+      )[0];
+    },
+
+    /**
+     * Encodes TimestampArbiterNonComposing.DemandData to bytes.
+     * @param demand - struct DemandData {uint64 minTimestamp, uint64 maxTimestamp}
+     * @returns abi encoded bytes
+     */
+    encodeTimestampArbiterNonComposingDemand: (demand: {
+      minTimestamp: bigint;
+      maxTimestamp: bigint;
+    }) => {
+      return encodeAbiParameters(
+        parseAbiParameters("(uint64 minTimestamp, uint64 maxTimestamp)"),
+        [demand],
+      );
+    },
+
+    /**
+     * Decodes TimestampArbiterNonComposing.DemandData from bytes.
+     * @param demandData - DemandData as abi encoded bytes
+     * @returns the decoded DemandData object
+     */
+    decodeTimestampArbiterNonComposingDemand: (demandData: `0x${string}`) => {
+      return decodeAbiParameters(
+        parseAbiParameters("(uint64 minTimestamp, uint64 maxTimestamp)"),
+        demandData,
+      )[0];
+    },
+
+    /**
+     * Encodes UidArbiterComposing.DemandData to bytes.
+     * @param demand - struct DemandData {address baseArbiter, bytes baseDemand, bytes32 expectedUID}
+     * @returns abi encoded bytes
+     */
+    encodeUidArbiterComposingDemand: (demand: {
+      baseArbiter: `0x${string}`;
+      baseDemand: `0x${string}`;
+      expectedUID: `0x${string}`;
+    }) => {
+      return encodeAbiParameters(
+        parseAbiParameters("(address baseArbiter, bytes baseDemand, bytes32 expectedUID)"),
+        [demand],
+      );
+    },
+
+    /**
+     * Decodes UidArbiterComposing.DemandData from bytes.
+     * @param demandData - DemandData as abi encoded bytes
+     * @returns the decoded DemandData object
+     */
+    decodeUidArbiterComposingDemand: (demandData: `0x${string}`) => {
+      return decodeAbiParameters(
+        parseAbiParameters("(address baseArbiter, bytes baseDemand, bytes32 expectedUID)"),
+        demandData,
+      )[0];
+    },
+
+    /**
+     * Encodes UidArbiterNonComposing.DemandData to bytes.
+     * @param demand - struct DemandData {bytes32 expectedUID}
+     * @returns abi encoded bytes
+     */
+    encodeUidArbiterNonComposingDemand: (demand: {
+      expectedUID: `0x${string}`;
+    }) => {
+      return encodeAbiParameters(
+        parseAbiParameters("(bytes32 expectedUID)"),
+        [demand],
+      );
+    },
+
+    /**
+     * Decodes UidArbiterNonComposing.DemandData from bytes.
+     * @param demandData - DemandData as abi encoded bytes
+     * @returns the decoded DemandData object
+     */
+    decodeUidArbiterNonComposingDemand: (demandData: `0x${string}`) => {
+      return decodeAbiParameters(
+        parseAbiParameters("(bytes32 expectedUID)"),
+        demandData,
+      )[0];
+    },
+
+    /**
+     * Encodes ValueArbiterComposing.DemandData to bytes.
+     * @param demand - struct DemandData {address baseArbiter, bytes baseDemand, uint256 minValue, uint256 maxValue}
+     * @returns abi encoded bytes
+     */
+    encodeValueArbiterComposingDemand: (demand: {
+      baseArbiter: `0x${string}`;
+      baseDemand: `0x${string}`;
+      minValue: bigint;
+      maxValue: bigint;
+    }) => {
+      return encodeAbiParameters(
+        parseAbiParameters("(address baseArbiter, bytes baseDemand, uint256 minValue, uint256 maxValue)"),
+        [demand],
+      );
+    },
+
+    /**
+     * Decodes ValueArbiterComposing.DemandData from bytes.
+     * @param demandData - DemandData as abi encoded bytes
+     * @returns the decoded DemandData object
+     */
+    decodeValueArbiterComposingDemand: (demandData: `0x${string}`) => {
+      return decodeAbiParameters(
+        parseAbiParameters("(address baseArbiter, bytes baseDemand, uint256 minValue, uint256 maxValue)"),
+        demandData,
+      )[0];
+    },
+
+    /**
+     * Encodes ValueArbiterNonComposing.DemandData to bytes.
+     * @param demand - struct DemandData {uint256 minValue, uint256 maxValue}
+     * @returns abi encoded bytes
+     */
+    encodeValueArbiterNonComposingDemand: (demand: {
+      minValue: bigint;
+      maxValue: bigint;
+    }) => {
+      return encodeAbiParameters(
+        parseAbiParameters("(uint256 minValue, uint256 maxValue)"),
+        [demand],
+      );
+    },
+
+    /**
+     * Decodes ValueArbiterNonComposing.DemandData from bytes.
+     * @param demandData - DemandData as abi encoded bytes
+     * @returns the decoded DemandData object
+     */
+    decodeValueArbiterNonComposingDemand: (demandData: `0x${string}`) => {
+      return decodeAbiParameters(
+        parseAbiParameters("(uint256 minValue, uint256 maxValue)"),
+        demandData,
+      )[0];
+    },
+  };
+};

--- a/src/clients/logicalArbiters.ts
+++ b/src/clients/logicalArbiters.ts
@@ -1,0 +1,68 @@
+import {
+  decodeAbiParameters,
+  encodeAbiParameters,
+  parseAbiParameters,
+} from "viem";
+import type { ViemClient } from "../utils";
+import type { ChainAddresses } from "../types";
+
+export const makeLogicalArbitersClient = (
+  viemClient: ViemClient,
+  addresses: ChainAddresses,
+) => {
+  return {
+    /**
+     * Encodes AnyArbiter.DemandData to bytes.
+     * @param demand - struct DemandData {address[] arbiters, bytes[] demands}
+     * @returns abi encoded bytes
+     */
+    encodeAnyArbiterDemand: (demand: {
+      arbiters: `0x${string}`[];
+      demands: `0x${string}`[];
+    }) => {
+      return encodeAbiParameters(
+        parseAbiParameters("(address[] arbiters, bytes[] demands)"),
+        [demand],
+      );
+    },
+
+    /**
+     * Decodes AnyArbiter.DemandData from bytes.
+     * @param demandData - DemandData as abi encoded bytes
+     * @returns the decoded DemandData object
+     */
+    decodeAnyArbiterDemand: (demandData: `0x${string}`) => {
+      return decodeAbiParameters(
+        parseAbiParameters("(address[] arbiters, bytes[] demands)"),
+        demandData,
+      )[0];
+    },
+
+    /**
+     * Encodes AllArbiter.DemandData to bytes.
+     * @param demand - struct DemandData {address[] arbiters, bytes[] demands}
+     * @returns abi encoded bytes
+     */
+    encodeAllArbiterDemand: (demand: {
+      arbiters: `0x${string}`[];
+      demands: `0x${string}`[];
+    }) => {
+      return encodeAbiParameters(
+        parseAbiParameters("(address[] arbiters, bytes[] demands)"),
+        [demand],
+      );
+    },
+
+    /**
+     * Decodes AllArbiter.DemandData from bytes.
+     * @param demandData - DemandData as abi encoded bytes
+     * @returns the decoded DemandData object
+     */
+    decodeAllArbiterDemand: (demandData: `0x${string}`) => {
+      return decodeAbiParameters(
+        parseAbiParameters("(address[] arbiters, bytes[] demands)"),
+        demandData,
+      )[0];
+    },
+  };
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,10 +8,12 @@ import {
   type WalletClient,
 } from "viem";
 import { makeArbitersClient } from "./clients/arbiters";
+import { makeAttestationPropertiesArbitersClient } from "./clients/attestationPropertiesArbiters";
 import { makeAttestationClient } from "./clients/attestation";
 import { makeErc1155Client } from "./clients/erc1155";
 import { makeErc20Client } from "./clients/erc20";
 import { makeErc721Client } from "./clients/erc721";
+import { makeLogicalArbitersClient } from "./clients/logicalArbiters";
 import { makeStringObligationClient } from "./clients/stringObligation";
 import { makeTokenBundleClient } from "./clients/tokenBundle";
 import {
@@ -167,11 +169,81 @@ export const makeClient = (
       contractAddresses?.anyArbiter || baseAddresses?.anyArbiter || zeroAddress,
     allArbiter:
       contractAddresses?.allArbiter || baseAddresses?.allArbiter || zeroAddress,
+
+    // Attestation Properties Arbiters - Composing
+    attesterArbiterComposing:
+      contractAddresses?.attesterArbiterComposing ||
+      baseAddresses?.attesterArbiterComposing,
+    expirationTimeArbiterComposing:
+      contractAddresses?.expirationTimeArbiterComposing ||
+      baseAddresses?.expirationTimeArbiterComposing,
+    recipientArbiterComposing:
+      contractAddresses?.recipientArbiterComposing ||
+      baseAddresses?.recipientArbiterComposing,
+    refUidArbiterComposing:
+      contractAddresses?.refUidArbiterComposing ||
+      baseAddresses?.refUidArbiterComposing,
+    revocableArbiterComposing:
+      contractAddresses?.revocableArbiterComposing ||
+      baseAddresses?.revocableArbiterComposing,
+    revocationTimeArbiterComposing:
+      contractAddresses?.revocationTimeArbiterComposing ||
+      baseAddresses?.revocationTimeArbiterComposing,
+    schemaArbiterComposing:
+      contractAddresses?.schemaArbiterComposing ||
+      baseAddresses?.schemaArbiterComposing,
+    timestampArbiterComposing:
+      contractAddresses?.timestampArbiterComposing ||
+      baseAddresses?.timestampArbiterComposing,
+    uidArbiterComposing:
+      contractAddresses?.uidArbiterComposing ||
+      baseAddresses?.uidArbiterComposing,
+    valueArbiterComposing:
+      contractAddresses?.valueArbiterComposing ||
+      baseAddresses?.valueArbiterComposing,
+
+    // Attestation Properties Arbiters - Non-Composing
+    attesterArbiterNonComposing:
+      contractAddresses?.attesterArbiterNonComposing ||
+      baseAddresses?.attesterArbiterNonComposing,
+    expirationTimeArbiterNonComposing:
+      contractAddresses?.expirationTimeArbiterNonComposing ||
+      baseAddresses?.expirationTimeArbiterNonComposing,
+    recipientArbiterNonComposing:
+      contractAddresses?.recipientArbiterNonComposing ||
+      baseAddresses?.recipientArbiterNonComposing,
+    refUidArbiterNonComposing:
+      contractAddresses?.refUidArbiterNonComposing ||
+      baseAddresses?.refUidArbiterNonComposing,
+    revocableArbiterNonComposing:
+      contractAddresses?.revocableArbiterNonComposing ||
+      baseAddresses?.revocableArbiterNonComposing,
+    revocationTimeArbiterNonComposing:
+      contractAddresses?.revocationTimeArbiterNonComposing ||
+      baseAddresses?.revocationTimeArbiterNonComposing,
+    schemaArbiterNonComposing:
+      contractAddresses?.schemaArbiterNonComposing ||
+      baseAddresses?.schemaArbiterNonComposing,
+    timestampArbiterNonComposing:
+      contractAddresses?.timestampArbiterNonComposing ||
+      baseAddresses?.timestampArbiterNonComposing,
+    uidArbiterNonComposing:
+      contractAddresses?.uidArbiterNonComposing ||
+      baseAddresses?.uidArbiterNonComposing,
+    valueArbiterNonComposing:
+      contractAddresses?.valueArbiterNonComposing ||
+      baseAddresses?.valueArbiterNonComposing,
   };
 
   return {
     /** Methods for interacting with Arbiters */
     arbiters: makeArbitersClient(viemClient, addresses),
+
+    /** Methods for interacting with Attestation Properties Arbiters */
+    attestationPropertiesArbiters: makeAttestationPropertiesArbitersClient(viemClient, addresses),
+
+    /** Methods for interacting with Logical Arbiters (Any/All) */
+    logicalArbiters: makeLogicalArbitersClient(viemClient, addresses),
 
     /** Methods for interacting with ERC20 tokens */
     erc20: makeErc20Client(viemClient, addresses),
@@ -283,3 +355,6 @@ export const makeClient = (
 
 export * from "./config";
 export * from "./types";
+export * from "./clients/arbiters";
+export * from "./clients/attestationPropertiesArbiters";
+export * from "./clients/logicalArbiters";

--- a/src/index.ts
+++ b/src/index.ts
@@ -173,66 +173,86 @@ export const makeClient = (
     // Attestation Properties Arbiters - Composing
     attesterArbiterComposing:
       contractAddresses?.attesterArbiterComposing ||
-      baseAddresses?.attesterArbiterComposing,
+      baseAddresses?.attesterArbiterComposing ||
+      zeroAddress,
     expirationTimeArbiterComposing:
       contractAddresses?.expirationTimeArbiterComposing ||
-      baseAddresses?.expirationTimeArbiterComposing,
+      baseAddresses?.expirationTimeArbiterComposing ||
+      zeroAddress,
     recipientArbiterComposing:
       contractAddresses?.recipientArbiterComposing ||
-      baseAddresses?.recipientArbiterComposing,
+      baseAddresses?.recipientArbiterComposing ||
+      zeroAddress,
     refUidArbiterComposing:
       contractAddresses?.refUidArbiterComposing ||
-      baseAddresses?.refUidArbiterComposing,
+      baseAddresses?.refUidArbiterComposing ||
+      zeroAddress,
     revocableArbiterComposing:
       contractAddresses?.revocableArbiterComposing ||
-      baseAddresses?.revocableArbiterComposing,
+      baseAddresses?.revocableArbiterComposing ||
+      zeroAddress,
     revocationTimeArbiterComposing:
       contractAddresses?.revocationTimeArbiterComposing ||
-      baseAddresses?.revocationTimeArbiterComposing,
+      baseAddresses?.revocationTimeArbiterComposing ||
+      zeroAddress,
     schemaArbiterComposing:
       contractAddresses?.schemaArbiterComposing ||
-      baseAddresses?.schemaArbiterComposing,
+      baseAddresses?.schemaArbiterComposing ||
+      zeroAddress,
     timestampArbiterComposing:
       contractAddresses?.timestampArbiterComposing ||
-      baseAddresses?.timestampArbiterComposing,
+      baseAddresses?.timestampArbiterComposing ||
+      zeroAddress,
     uidArbiterComposing:
       contractAddresses?.uidArbiterComposing ||
-      baseAddresses?.uidArbiterComposing,
+      baseAddresses?.uidArbiterComposing ||
+      zeroAddress,
     valueArbiterComposing:
       contractAddresses?.valueArbiterComposing ||
-      baseAddresses?.valueArbiterComposing,
+      baseAddresses?.valueArbiterComposing ||
+      zeroAddress,
 
     // Attestation Properties Arbiters - Non-Composing
     attesterArbiterNonComposing:
       contractAddresses?.attesterArbiterNonComposing ||
-      baseAddresses?.attesterArbiterNonComposing,
+      baseAddresses?.attesterArbiterNonComposing ||
+      zeroAddress,
     expirationTimeArbiterNonComposing:
       contractAddresses?.expirationTimeArbiterNonComposing ||
-      baseAddresses?.expirationTimeArbiterNonComposing,
+      baseAddresses?.expirationTimeArbiterNonComposing ||
+      zeroAddress,
     recipientArbiterNonComposing:
       contractAddresses?.recipientArbiterNonComposing ||
-      baseAddresses?.recipientArbiterNonComposing,
+      baseAddresses?.recipientArbiterNonComposing ||
+      zeroAddress,
     refUidArbiterNonComposing:
       contractAddresses?.refUidArbiterNonComposing ||
-      baseAddresses?.refUidArbiterNonComposing,
+      baseAddresses?.refUidArbiterNonComposing ||
+      zeroAddress,
     revocableArbiterNonComposing:
       contractAddresses?.revocableArbiterNonComposing ||
-      baseAddresses?.revocableArbiterNonComposing,
+      baseAddresses?.revocableArbiterNonComposing ||
+      zeroAddress,
     revocationTimeArbiterNonComposing:
       contractAddresses?.revocationTimeArbiterNonComposing ||
-      baseAddresses?.revocationTimeArbiterNonComposing,
+      baseAddresses?.revocationTimeArbiterNonComposing ||
+      zeroAddress,
     schemaArbiterNonComposing:
       contractAddresses?.schemaArbiterNonComposing ||
-      baseAddresses?.schemaArbiterNonComposing,
+      baseAddresses?.schemaArbiterNonComposing ||
+      zeroAddress,
     timestampArbiterNonComposing:
       contractAddresses?.timestampArbiterNonComposing ||
-      baseAddresses?.timestampArbiterNonComposing,
+      baseAddresses?.timestampArbiterNonComposing ||
+      zeroAddress,
     uidArbiterNonComposing:
       contractAddresses?.uidArbiterNonComposing ||
-      baseAddresses?.uidArbiterNonComposing,
+      baseAddresses?.uidArbiterNonComposing ||
+      zeroAddress,
     valueArbiterNonComposing:
       contractAddresses?.valueArbiterNonComposing ||
-      baseAddresses?.valueArbiterNonComposing,
+      baseAddresses?.valueArbiterNonComposing ||
+      zeroAddress,
   };
 
   return {

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,6 +34,30 @@ export type ChainAddresses = {
   allArbiter: `0x${string}`;
   intrinsicsArbiter: `0x${string}`;
   intrinsicsArbiter2: `0x${string}`;
+
+  // Attestation Properties Arbiters - Composing
+  attesterArbiterComposing?: `0x${string}`;
+  expirationTimeArbiterComposing?: `0x${string}`;
+  recipientArbiterComposing?: `0x${string}`;
+  refUidArbiterComposing?: `0x${string}`;
+  revocableArbiterComposing?: `0x${string}`;
+  revocationTimeArbiterComposing?: `0x${string}`;
+  schemaArbiterComposing?: `0x${string}`;
+  timestampArbiterComposing?: `0x${string}`;
+  uidArbiterComposing?: `0x${string}`;
+  valueArbiterComposing?: `0x${string}`;
+
+  // Attestation Properties Arbiters - Non-Composing
+  attesterArbiterNonComposing?: `0x${string}`;
+  expirationTimeArbiterNonComposing?: `0x${string}`;
+  recipientArbiterNonComposing?: `0x${string}`;
+  refUidArbiterNonComposing?: `0x${string}`;
+  revocableArbiterNonComposing?: `0x${string}`;
+  revocationTimeArbiterNonComposing?: `0x${string}`;
+  schemaArbiterNonComposing?: `0x${string}`;
+  timestampArbiterNonComposing?: `0x${string}`;
+  uidArbiterNonComposing?: `0x${string}`;
+  valueArbiterNonComposing?: `0x${string}`;
 };
 
 export type PermitSignature = {

--- a/tests/unit/attestationPropertiesArbiters.test.ts
+++ b/tests/unit/attestationPropertiesArbiters.test.ts
@@ -1,0 +1,520 @@
+/**
+ * Attestation Properties Arbiters Unit Tests
+ *
+ * This file contains tests for the attestation properties arbiters client functionality, including:
+ * - AttesterArbiter (Composing & NonComposing)
+ * - ExpirationTimeArbiter (Composing & NonComposing)
+ * - RecipientArbiter (Composing & NonComposing)
+ * - RefUidArbiter (Composing & NonComposing)
+ * - RevocableArbiter (Composing & NonComposing)
+ * - RevocationTimeArbiter (Composing & NonComposing)
+ * - SchemaArbiter (Composing & NonComposing)
+ * - TimestampArbiter (Composing & NonComposing)
+ * - UidArbiter (Composing & NonComposing)
+ * - ValueArbiter (Composing & NonComposing)
+ */
+
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import { encodeAbiParameters, parseAbiParameters } from "viem";
+import {
+  setupTestEnvironment,
+  teardownTestEnvironment,
+  type TestContext,
+} from "../utils/setup";
+import { generatePrivateKey, privateKeyToAddress } from "viem/accounts";
+
+describe("Attestation Properties Arbiters Tests", () => {
+  let testContext: TestContext;
+  let alice: `0x${string}`;
+  let bob: `0x${string}`;
+  let testClient: TestContext["testClient"];
+
+  beforeAll(async () => {
+    testContext = await setupTestEnvironment();
+    
+    // Generate test accounts
+    const alicePrivateKey = generatePrivateKey();
+    const bobPrivateKey = generatePrivateKey();
+    alice = privateKeyToAddress(alicePrivateKey);
+    bob = privateKeyToAddress(bobPrivateKey);
+    
+    testClient = testContext.testClient;
+  });
+
+  afterAll(async () => {
+    await teardownTestEnvironment(testContext);
+  });
+
+  describe("AttesterArbiter", () => {
+    describe("Composing variant", () => {
+      test("should encode and decode AttesterArbiterComposing demand data correctly", () => {
+        const client = testContext.aliceClient;
+        
+        const originalDemand = {
+          baseArbiter: alice,
+          baseDemand: "0x1234567890abcdef" as `0x${string}`,
+          expectedAttester: bob,
+        };
+
+        // Test encoding
+        const encoded = client.attestationPropertiesArbiters.encodeAttesterArbiterComposingDemand(originalDemand);
+        expect(encoded).toMatch(/^0x[0-9a-f]+$/i);
+
+        // Test decoding
+        const decoded = client.attestationPropertiesArbiters.decodeAttesterArbiterComposingDemand(encoded);
+        expect(decoded.baseArbiter).toBe(originalDemand.baseArbiter);
+        expect(decoded.baseDemand).toBe(originalDemand.baseDemand);
+        expect(decoded.expectedAttester).toBe(originalDemand.expectedAttester);
+      });
+
+      test("should handle empty baseDemand", () => {
+        const client = testContext.aliceClient;
+        
+        const demand = {
+          baseArbiter: alice,
+          baseDemand: "0x" as `0x${string}`,
+          expectedAttester: bob,
+        };
+
+        const encoded = client.attestationPropertiesArbiters.encodeAttesterArbiterComposingDemand(demand);
+        const decoded = client.attestationPropertiesArbiters.decodeAttesterArbiterComposingDemand(encoded);
+        
+        expect(decoded.baseDemand).toBe("0x");
+      });
+    });
+
+    describe("NonComposing variant", () => {
+      test("should encode and decode AttesterArbiterNonComposing demand data correctly", () => {
+        const client = testContext.aliceClient;
+        
+        const originalDemand = {
+          expectedAttester: alice,
+        };
+
+        // Test encoding
+        const encoded = client.attestationPropertiesArbiters.encodeAttesterArbiterNonComposingDemand(originalDemand);
+        expect(encoded).toMatch(/^0x[0-9a-f]+$/i);
+
+        // Test decoding
+        const decoded = client.attestationPropertiesArbiters.decodeAttesterArbiterNonComposingDemand(encoded);
+        expect(decoded.expectedAttester).toBe(originalDemand.expectedAttester);
+      });
+    });
+  });
+
+  describe("ExpirationTimeArbiter", () => {
+    describe("Composing variant", () => {
+      test("should encode and decode ExpirationTimeArbiterComposing demand data correctly", () => {
+        const client = testContext.aliceClient;
+        
+        const originalDemand = {
+          baseArbiter: alice,
+          baseDemand: "0xabcdef1234567890" as `0x${string}`,
+          minExpirationTime: 1735689600n, // BigInt timestamp
+          maxExpirationTime: 1735689900n, // BigInt timestamp
+        };
+
+        const encoded = client.attestationPropertiesArbiters.encodeExpirationTimeArbiterComposingDemand(originalDemand);
+        const decoded = client.attestationPropertiesArbiters.decodeExpirationTimeArbiterComposingDemand(encoded);
+        
+        expect(decoded.baseArbiter).toBe(originalDemand.baseArbiter);
+        expect(decoded.baseDemand).toBe(originalDemand.baseDemand);
+        expect(decoded.minExpirationTime).toBe(originalDemand.minExpirationTime);
+        expect(decoded.maxExpirationTime).toBe(originalDemand.maxExpirationTime);
+      });
+    });
+
+    describe("NonComposing variant", () => {
+      test("should encode and decode ExpirationTimeArbiterNonComposing demand data correctly", () => {
+        const client = testContext.aliceClient;
+        
+        const originalDemand = {
+          minExpirationTime: 1735689600n,
+          maxExpirationTime: 1735689900n,
+        };
+
+        const encoded = client.attestationPropertiesArbiters.encodeExpirationTimeArbiterNonComposingDemand(originalDemand);
+        const decoded = client.attestationPropertiesArbiters.decodeExpirationTimeArbiterNonComposingDemand(encoded);
+        
+        expect(decoded.minExpirationTime).toBe(originalDemand.minExpirationTime);
+        expect(decoded.maxExpirationTime).toBe(originalDemand.maxExpirationTime);
+      });
+    });
+  });
+
+  describe("RecipientArbiter", () => {
+    describe("Composing variant", () => {
+      test("should encode and decode RecipientArbiterComposing demand data correctly", () => {
+        const client = testContext.aliceClient;
+        
+        const originalDemand = {
+          baseArbiter: alice,
+          baseDemand: "0x" as `0x${string}`,
+          expectedRecipient: bob,
+        };
+
+        const encoded = client.attestationPropertiesArbiters.encodeRecipientArbiterComposingDemand(originalDemand);
+        const decoded = client.attestationPropertiesArbiters.decodeRecipientArbiterComposingDemand(encoded);
+        
+        expect(decoded.baseArbiter).toBe(originalDemand.baseArbiter);
+        expect(decoded.baseDemand).toBe(originalDemand.baseDemand);
+        expect(decoded.expectedRecipient).toBe(originalDemand.expectedRecipient);
+      });
+    });
+
+    describe("NonComposing variant", () => {
+      test("should encode and decode RecipientArbiterNonComposing demand data correctly", () => {
+        const client = testContext.aliceClient;
+        
+        const originalDemand = {
+          expectedRecipient: bob,
+        };
+
+        const encoded = client.attestationPropertiesArbiters.encodeRecipientArbiterNonComposingDemand(originalDemand);
+        const decoded = client.attestationPropertiesArbiters.decodeRecipientArbiterNonComposingDemand(encoded);
+        
+        expect(decoded.expectedRecipient).toBe(originalDemand.expectedRecipient);
+      });
+    });
+  });
+
+  describe("RefUidArbiter", () => {
+    describe("Composing variant", () => {
+      test("should encode and decode RefUidArbiterComposing demand data correctly", () => {
+        const client = testContext.aliceClient;
+        
+        const originalDemand = {
+          baseArbiter: alice,
+          baseDemand: "0x1111" as `0x${string}`,
+          expectedRefUID: "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef" as `0x${string}`,
+        };
+
+        const encoded = client.attestationPropertiesArbiters.encodeRefUidArbiterComposingDemand(originalDemand);
+        const decoded = client.attestationPropertiesArbiters.decodeRefUidArbiterComposingDemand(encoded);
+        
+        expect(decoded.baseArbiter).toBe(originalDemand.baseArbiter);
+        expect(decoded.baseDemand).toBe(originalDemand.baseDemand);
+        expect(decoded.expectedRefUID).toBe(originalDemand.expectedRefUID);
+      });
+    });
+
+    describe("NonComposing variant", () => {
+      test("should encode and decode RefUidArbiterNonComposing demand data correctly", () => {
+        const client = testContext.aliceClient;
+        
+        const originalDemand = {
+          expectedRefUID: "0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd" as `0x${string}`,
+        };
+
+        const encoded = client.attestationPropertiesArbiters.encodeRefUidArbiterNonComposingDemand(originalDemand);
+        const decoded = client.attestationPropertiesArbiters.decodeRefUidArbiterNonComposingDemand(encoded);
+        
+        expect(decoded.expectedRefUID).toBe(originalDemand.expectedRefUID);
+      });
+    });
+  });
+
+  describe("RevocableArbiter", () => {
+    describe("Composing variant", () => {
+      test("should encode and decode RevocableArbiterComposing demand data correctly", () => {
+        const client = testContext.aliceClient;
+        
+        const originalDemand = {
+          baseArbiter: alice,
+          baseDemand: "0x2222" as `0x${string}`,
+          expectedRevocable: true,
+        };
+
+        const encoded = client.attestationPropertiesArbiters.encodeRevocableArbiterComposingDemand(originalDemand);
+        const decoded = client.attestationPropertiesArbiters.decodeRevocableArbiterComposingDemand(encoded);
+        
+        expect(decoded.baseArbiter).toBe(originalDemand.baseArbiter);
+        expect(decoded.baseDemand).toBe(originalDemand.baseDemand);
+        expect(decoded.expectedRevocable).toBe(originalDemand.expectedRevocable);
+      });
+
+      test("should handle false revocable value", () => {
+        const client = testContext.aliceClient;
+        
+        const originalDemand = {
+          baseArbiter: alice,
+          baseDemand: "0x" as `0x${string}`,
+          expectedRevocable: false,
+        };
+
+        const encoded = client.attestationPropertiesArbiters.encodeRevocableArbiterComposingDemand(originalDemand);
+        const decoded = client.attestationPropertiesArbiters.decodeRevocableArbiterComposingDemand(encoded);
+        
+        expect(decoded.expectedRevocable).toBe(false);
+      });
+    });
+
+    describe("NonComposing variant", () => {
+      test("should encode and decode RevocableArbiterNonComposing demand data correctly", () => {
+        const client = testContext.aliceClient;
+        
+        const originalDemand = {
+          expectedRevocable: true,
+        };
+
+        const encoded = client.attestationPropertiesArbiters.encodeRevocableArbiterNonComposingDemand(originalDemand);
+        const decoded = client.attestationPropertiesArbiters.decodeRevocableArbiterNonComposingDemand(encoded);
+        
+        expect(decoded.expectedRevocable).toBe(originalDemand.expectedRevocable);
+      });
+    });
+  });
+
+  describe("RevocationTimeArbiter", () => {
+    describe("Composing variant", () => {
+      test("should encode and decode RevocationTimeArbiterComposing demand data correctly", () => {
+        const client = testContext.aliceClient;
+        
+        const originalDemand = {
+          baseArbiter: alice,
+          baseDemand: "0x3333" as `0x${string}`,
+          minRevocationTime: 1735689600n,
+          maxRevocationTime: 1735689900n,
+        };
+
+        const encoded = client.attestationPropertiesArbiters.encodeRevocationTimeArbiterComposingDemand(originalDemand);
+        const decoded = client.attestationPropertiesArbiters.decodeRevocationTimeArbiterComposingDemand(encoded);
+        
+        expect(decoded.baseArbiter).toBe(originalDemand.baseArbiter);
+        expect(decoded.baseDemand).toBe(originalDemand.baseDemand);
+        expect(decoded.minRevocationTime).toBe(originalDemand.minRevocationTime);
+        expect(decoded.maxRevocationTime).toBe(originalDemand.maxRevocationTime);
+      });
+    });
+
+    describe("NonComposing variant", () => {
+      test("should encode and decode RevocationTimeArbiterNonComposing demand data correctly", () => {
+        const client = testContext.aliceClient;
+        
+        const originalDemand = {
+          minRevocationTime: 0n, // 0 means not revoked
+          maxRevocationTime: 1735689900n,
+        };
+
+        const encoded = client.attestationPropertiesArbiters.encodeRevocationTimeArbiterNonComposingDemand(originalDemand);
+        const decoded = client.attestationPropertiesArbiters.decodeRevocationTimeArbiterNonComposingDemand(encoded);
+        
+        expect(decoded.minRevocationTime).toBe(originalDemand.minRevocationTime);
+        expect(decoded.maxRevocationTime).toBe(originalDemand.maxRevocationTime);
+      });
+    });
+  });
+
+  describe("SchemaArbiter", () => {
+    describe("Composing variant", () => {
+      test("should encode and decode SchemaArbiterComposing demand data correctly", () => {
+        const client = testContext.aliceClient;
+        
+        const originalDemand = {
+          baseArbiter: alice,
+          baseDemand: "0x4444" as `0x${string}`,
+          expectedSchema: "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef" as `0x${string}`,
+        };
+
+        const encoded = client.attestationPropertiesArbiters.encodeSchemaArbiterComposingDemand(originalDemand);
+        const decoded = client.attestationPropertiesArbiters.decodeSchemaArbiterComposingDemand(encoded);
+        
+        expect(decoded.baseArbiter).toBe(originalDemand.baseArbiter);
+        expect(decoded.baseDemand).toBe(originalDemand.baseDemand);
+        expect(decoded.expectedSchema).toBe(originalDemand.expectedSchema);
+      });
+    });
+
+    describe("NonComposing variant", () => {
+      test("should encode and decode SchemaArbiterNonComposing demand data correctly", () => {
+        const client = testContext.aliceClient;
+        
+        const originalDemand = {
+          expectedSchema: "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef" as `0x${string}`,
+        };
+
+        const encoded = client.attestationPropertiesArbiters.encodeSchemaArbiterNonComposingDemand(originalDemand);
+        const decoded = client.attestationPropertiesArbiters.decodeSchemaArbiterNonComposingDemand(encoded);
+        
+        expect(decoded.expectedSchema).toBe(originalDemand.expectedSchema);
+      });
+    });
+  });
+
+  describe("TimestampArbiter", () => {
+    describe("Composing variant", () => {
+      test("should encode and decode TimestampArbiterComposing demand data correctly", () => {
+        const client = testContext.aliceClient;
+        
+        const originalDemand = {
+          baseArbiter: alice,
+          baseDemand: "0x5555" as `0x${string}`,
+          minTimestamp: 1735689600n,
+          maxTimestamp: 1735689900n,
+        };
+
+        const encoded = client.attestationPropertiesArbiters.encodeTimestampArbiterComposingDemand(originalDemand);
+        const decoded = client.attestationPropertiesArbiters.decodeTimestampArbiterComposingDemand(encoded);
+        
+        expect(decoded.baseArbiter).toBe(originalDemand.baseArbiter);
+        expect(decoded.baseDemand).toBe(originalDemand.baseDemand);
+        expect(decoded.minTimestamp).toBe(originalDemand.minTimestamp);
+        expect(decoded.maxTimestamp).toBe(originalDemand.maxTimestamp);
+      });
+    });
+
+    describe("NonComposing variant", () => {
+      test("should encode and decode TimestampArbiterNonComposing demand data correctly", () => {
+        const client = testContext.aliceClient;
+        
+        const originalDemand = {
+          minTimestamp: 1735689600n,
+          maxTimestamp: 1735689900n,
+        };
+
+        const encoded = client.attestationPropertiesArbiters.encodeTimestampArbiterNonComposingDemand(originalDemand);
+        const decoded = client.attestationPropertiesArbiters.decodeTimestampArbiterNonComposingDemand(encoded);
+        
+        expect(decoded.minTimestamp).toBe(originalDemand.minTimestamp);
+        expect(decoded.maxTimestamp).toBe(originalDemand.maxTimestamp);
+      });
+    });
+  });
+
+  describe("UidArbiter", () => {
+    describe("Composing variant", () => {
+      test("should encode and decode UidArbiterComposing demand data correctly", () => {
+        const client = testContext.aliceClient;
+        
+        const originalDemand = {
+          baseArbiter: alice,
+          baseDemand: "0x6666" as `0x${string}`,
+          expectedUID: "0x1111111111111111111111111111111111111111111111111111111111111111" as `0x${string}`,
+        };
+
+        const encoded = client.attestationPropertiesArbiters.encodeUidArbiterComposingDemand(originalDemand);
+        const decoded = client.attestationPropertiesArbiters.decodeUidArbiterComposingDemand(encoded);
+        
+        expect(decoded.baseArbiter).toBe(originalDemand.baseArbiter);
+        expect(decoded.baseDemand).toBe(originalDemand.baseDemand);
+        expect(decoded.expectedUID).toBe(originalDemand.expectedUID);
+      });
+    });
+
+    describe("NonComposing variant", () => {
+      test("should encode and decode UidArbiterNonComposing demand data correctly", () => {
+        const client = testContext.aliceClient;
+        
+        const originalDemand = {
+          expectedUID: "0x2222222222222222222222222222222222222222222222222222222222222222" as `0x${string}`,
+        };
+
+        const encoded = client.attestationPropertiesArbiters.encodeUidArbiterNonComposingDemand(originalDemand);
+        const decoded = client.attestationPropertiesArbiters.decodeUidArbiterNonComposingDemand(encoded);
+        
+        expect(decoded.expectedUID).toBe(originalDemand.expectedUID);
+      });
+    });
+  });
+
+  describe("ValueArbiter", () => {
+    describe("Composing variant", () => {
+      test("should encode and decode ValueArbiterComposing demand data correctly", () => {
+        const client = testContext.aliceClient;
+        
+        const originalDemand = {
+          baseArbiter: alice,
+          baseDemand: "0x7777" as `0x${string}`,
+          minValue: 1000000000000000000n, // 1 ETH in wei
+          maxValue: 2000000000000000000n, // 2 ETH in wei
+        };
+
+        const encoded = client.attestationPropertiesArbiters.encodeValueArbiterComposingDemand(originalDemand);
+        const decoded = client.attestationPropertiesArbiters.decodeValueArbiterComposingDemand(encoded);
+        
+        expect(decoded.baseArbiter).toBe(originalDemand.baseArbiter);
+        expect(decoded.baseDemand).toBe(originalDemand.baseDemand);
+        expect(decoded.minValue).toBe(originalDemand.minValue);
+        expect(decoded.maxValue).toBe(originalDemand.maxValue);
+      });
+    });
+
+    describe("NonComposing variant", () => {
+      test("should encode and decode ValueArbiterNonComposing demand data correctly", () => {
+        const client = testContext.aliceClient;
+        
+        const originalDemand = {
+          minValue: 0n, // Free attestation
+          maxValue: 1000000000000000000n, // Max 1 ETH
+        };
+
+        const encoded = client.attestationPropertiesArbiters.encodeValueArbiterNonComposingDemand(originalDemand);
+        const decoded = client.attestationPropertiesArbiters.decodeValueArbiterNonComposingDemand(encoded);
+        
+        expect(decoded.minValue).toBe(originalDemand.minValue);
+        expect(decoded.maxValue).toBe(originalDemand.maxValue);
+      });
+
+      test("should handle large values", () => {
+        const client = testContext.aliceClient;
+        
+        const originalDemand = {
+          minValue: 999999999999999999999999n, // Very large value
+          maxValue: 1000000000000000000000000n, // Even larger value
+        };
+
+        const encoded = client.attestationPropertiesArbiters.encodeValueArbiterNonComposingDemand(originalDemand);
+        const decoded = client.attestationPropertiesArbiters.decodeValueArbiterNonComposingDemand(encoded);
+        
+        expect(decoded.minValue).toBe(originalDemand.minValue);
+        expect(decoded.maxValue).toBe(originalDemand.maxValue);
+      });
+    });
+  });
+
+  describe("Error handling", () => {
+    test("should throw error for invalid hex data", () => {
+      const client = testContext.aliceClient;
+      
+      expect(() => {
+        client.attestationPropertiesArbiters.decodeAttesterArbiterComposingDemand("invalid-hex" as `0x${string}`);
+      }).toThrow();
+    });
+
+    test("should throw error for insufficient data", () => {
+      const client = testContext.aliceClient;
+      
+      expect(() => {
+        client.attestationPropertiesArbiters.decodeAttesterArbiterComposingDemand("0x123" as `0x${string}`);
+      }).toThrow();
+    });
+  });
+
+  describe("Integration with manual encoding", () => {
+    test("should produce same result as manual ABI encoding", () => {
+      const client = testContext.aliceClient;
+      
+      const demand = {
+        expectedAttester: alice,
+      };
+      
+      // Manual encoding using viem directly
+      const manualEncoded = encodeAbiParameters(
+        parseAbiParameters("(address expectedAttester)"),
+        [demand]
+      );
+      
+      // SDK encoding
+      const sdkEncoded = client.attestationPropertiesArbiters.encodeAttesterArbiterNonComposingDemand(demand);
+      
+      expect(sdkEncoded).toBe(manualEncoded);
+    });
+  });
+});

--- a/tests/unit/logicalArbiters.test.ts
+++ b/tests/unit/logicalArbiters.test.ts
@@ -1,0 +1,476 @@
+/**
+ * Logical Arbiters Unit Tests
+ *
+ * This file contains tests for the logical arbiters client functionality, including:
+ * - AnyArbiter - validates if any of the provided arbiters pass
+ * - AllArbiter - validates if all of the provided arbiters pass
+ */
+
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import { encodeAbiParameters, parseAbiParameters } from "viem";
+import {
+  setupTestEnvironment,
+  teardownTestEnvironment,
+  type TestContext,
+} from "../utils/setup";
+import { generatePrivateKey, privateKeyToAddress } from "viem/accounts";
+
+describe("Logical Arbiters Tests", () => {
+  let testContext: TestContext;
+  let alice: `0x${string}`;
+  let bob: `0x${string}`;
+  let charlie: `0x${string}`;
+  let testClient: TestContext["testClient"];
+
+  // Helper function to compare addresses case-insensitively
+  const expectAddressesEqual = (actual: readonly `0x${string}`[], expected: `0x${string}`[]) => {
+    expect(actual.map(addr => addr.toLowerCase())).toEqual(expected.map(addr => addr.toLowerCase()));
+  };
+
+  // Helper function to compare hex strings case-insensitively
+  const expectHexEqual = (actual: readonly `0x${string}`[], expected: `0x${string}`[]) => {
+    expect(actual.map(hex => hex.toLowerCase())).toEqual(expected.map(hex => hex.toLowerCase()));
+  };
+
+  beforeAll(async () => {
+    testContext = await setupTestEnvironment();
+    
+    // Generate test accounts
+    const alicePrivateKey = generatePrivateKey();
+    const bobPrivateKey = generatePrivateKey();
+    const charliePrivateKey = generatePrivateKey();
+    alice = privateKeyToAddress(alicePrivateKey);
+    bob = privateKeyToAddress(bobPrivateKey);
+    charlie = privateKeyToAddress(charliePrivateKey);
+    
+    testClient = testContext.testClient;
+  });
+
+  afterAll(async () => {
+    await teardownTestEnvironment(testContext);
+  });
+
+  describe("AnyArbiter", () => {
+    test("should encode and decode AnyArbiter demand data correctly", () => {
+      const client = testContext.aliceClient;
+      
+      const originalDemand = {
+        arbiters: [alice, bob, charlie],
+        demands: [
+          "0x1234" as `0x${string}`,
+          "0x5678" as `0x${string}`,
+          "0xabcd" as `0x${string}`,
+        ],
+      };
+
+      // Test encoding
+      const encoded = client.logicalArbiters.encodeAnyArbiterDemand(originalDemand);
+      expect(encoded).toMatch(/^0x[0-9a-f]+$/i);
+
+      // Test decoding
+      const decoded = client.logicalArbiters.decodeAnyArbiterDemand(encoded);
+      expectAddressesEqual(decoded.arbiters, originalDemand.arbiters);
+      expect(decoded.demands).toEqual(originalDemand.demands);
+    });
+
+    test("should handle single arbiter", () => {
+      const client = testContext.aliceClient;
+      
+      const originalDemand = {
+        arbiters: [alice],
+        demands: ["0x1234567890abcdef" as `0x${string}`],
+      };
+
+      const encoded = client.logicalArbiters.encodeAnyArbiterDemand(originalDemand);
+      const decoded = client.logicalArbiters.decodeAnyArbiterDemand(encoded);
+      
+      expectAddressesEqual(decoded.arbiters, originalDemand.arbiters);
+      expect(decoded.demands).toEqual(originalDemand.demands);
+    });
+
+    test("should handle empty demands", () => {
+      const client = testContext.aliceClient;
+      
+      const originalDemand = {
+        arbiters: [alice, bob],
+        demands: ["0x" as `0x${string}`, "0x" as `0x${string}`],
+      };
+
+      const encoded = client.logicalArbiters.encodeAnyArbiterDemand(originalDemand);
+      const decoded = client.logicalArbiters.decodeAnyArbiterDemand(encoded);
+      
+      expectAddressesEqual(decoded.arbiters, originalDemand.arbiters);
+      expect(decoded.demands).toEqual(originalDemand.demands);
+    });
+
+    test("should handle many arbiters", () => {
+      const client = testContext.aliceClient;
+      
+      // Generate 10 test addresses
+      const arbiters = Array.from({ length: 10 }, () => 
+        privateKeyToAddress(generatePrivateKey())
+      );
+      const demands = Array.from({ length: 10 }, (_, i) => 
+        `0x${i.toString(16).padStart(4, "0")}` as `0x${string}`
+      );
+      
+      const originalDemand = { arbiters, demands };
+
+      const encoded = client.logicalArbiters.encodeAnyArbiterDemand(originalDemand);
+      const decoded = client.logicalArbiters.decodeAnyArbiterDemand(encoded);
+      
+      expectAddressesEqual(decoded.arbiters, originalDemand.arbiters);
+      expect(decoded.demands).toEqual(originalDemand.demands);
+    });
+
+    test("should handle complex demand data", () => {
+      const client = testContext.aliceClient;
+      
+      const originalDemand = {
+        arbiters: [alice, bob],
+        demands: [
+          // Complex encoded data (e.g., from another arbiter)
+          "0x000000000000000000000000" + alice.slice(2) + "0000000000000000000000000000000000000000000000000000000000000040000000000000000000000000" + bob.slice(2) + "0000000000000000000000000000000000000000000000000000000000000004deadbeef00000000000000000000000000000000000000000000000000000000" as `0x${string}`,
+          "0x" as `0x${string}`,
+        ],
+      };
+
+      const encoded = client.logicalArbiters.encodeAnyArbiterDemand(originalDemand);
+      const decoded = client.logicalArbiters.decodeAnyArbiterDemand(encoded);
+      
+      expectAddressesEqual(decoded.arbiters, originalDemand.arbiters);
+      expectHexEqual(decoded.demands, originalDemand.demands);
+    });
+
+    test("should handle mismatched array lengths", () => {
+      const client = testContext.aliceClient;
+      
+      // The implementation doesn't validate array lengths, so this should encode successfully
+      // but may not be meaningful for actual contract usage
+      const demand = {
+        arbiters: [alice, bob],
+        demands: ["0x1234" as `0x${string}`], // Length mismatch
+      };
+      
+      const encoded = client.logicalArbiters.encodeAnyArbiterDemand(demand);
+      expect(encoded).toMatch(/^0x[0-9a-f]+$/i);
+      
+      const decoded = client.logicalArbiters.decodeAnyArbiterDemand(encoded);
+      expectAddressesEqual(decoded.arbiters, demand.arbiters);
+      expect(decoded.demands).toEqual(demand.demands);
+    });
+  });
+
+  describe("AllArbiter", () => {
+    test("should encode and decode AllArbiter demand data correctly", () => {
+      const client = testContext.aliceClient;
+      
+      const originalDemand = {
+        arbiters: [alice, bob, charlie],
+        demands: [
+          "0x1111" as `0x${string}`,
+          "0x2222" as `0x${string}`,
+          "0x3333" as `0x${string}`,
+        ],
+      };
+
+      // Test encoding
+      const encoded = client.logicalArbiters.encodeAllArbiterDemand(originalDemand);
+      expect(encoded).toMatch(/^0x[0-9a-f]+$/i);
+
+      // Test decoding
+      const decoded = client.logicalArbiters.decodeAllArbiterDemand(encoded);
+      expectAddressesEqual(decoded.arbiters, originalDemand.arbiters);
+      expect(decoded.demands).toEqual(originalDemand.demands);
+    });
+
+    test("should handle single arbiter", () => {
+      const client = testContext.aliceClient;
+      
+      const originalDemand = {
+        arbiters: [bob],
+        demands: ["0xfedcba9876543210" as `0x${string}`],
+      };
+
+      const encoded = client.logicalArbiters.encodeAllArbiterDemand(originalDemand);
+      const decoded = client.logicalArbiters.decodeAllArbiterDemand(encoded);
+      
+      expectAddressesEqual(decoded.arbiters, originalDemand.arbiters);
+      expect(decoded.demands).toEqual(originalDemand.demands);
+    });
+
+    test("should handle empty arrays", () => {
+      const client = testContext.aliceClient;
+      
+      const originalDemand = {
+        arbiters: [] as `0x${string}`[],
+        demands: [] as `0x${string}`[],
+      };
+
+      const encoded = client.logicalArbiters.encodeAllArbiterDemand(originalDemand);
+      const decoded = client.logicalArbiters.decodeAllArbiterDemand(encoded);
+      
+      expectAddressesEqual(decoded.arbiters, originalDemand.arbiters);
+      expect(decoded.demands).toEqual(originalDemand.demands);
+    });
+
+    test("should handle large datasets", () => {
+      const client = testContext.aliceClient;
+      
+      // Generate 50 test addresses and demands
+      const arbiters = Array.from({ length: 50 }, () => 
+        privateKeyToAddress(generatePrivateKey())
+      );
+      const demands = Array.from({ length: 50 }, (_, i) => 
+        `0x${i.toString(16).padStart(8, "0")}` as `0x${string}`
+      );
+      
+      const originalDemand = { arbiters, demands };
+
+      const encoded = client.logicalArbiters.encodeAllArbiterDemand(originalDemand);
+      const decoded = client.logicalArbiters.decodeAllArbiterDemand(encoded);
+      
+      expectAddressesEqual(decoded.arbiters, originalDemand.arbiters);
+      expect(decoded.demands).toEqual(originalDemand.demands);
+    });
+
+    test("should handle varied demand lengths", () => {
+      const client = testContext.aliceClient;
+      
+      const originalDemand = {
+        arbiters: [alice, bob, charlie],
+        demands: [
+          "0x" as `0x${string}`, // Empty
+          "0x1234" as `0x${string}`, // Short
+          "0x123456789abcdef123456789abcdef123456789abcdef123456789abcdef12" as `0x${string}`, // Long
+        ],
+      };
+
+      const encoded = client.logicalArbiters.encodeAllArbiterDemand(originalDemand);
+      const decoded = client.logicalArbiters.decodeAllArbiterDemand(encoded);
+      
+      expectAddressesEqual(decoded.arbiters, originalDemand.arbiters);
+      expect(decoded.demands).toEqual(originalDemand.demands);
+    });
+  });
+
+  describe("Cross-compatibility", () => {
+    test("AnyArbiter and AllArbiter should use the same encoding format", () => {
+      const client = testContext.aliceClient;
+      
+      const demand = {
+        arbiters: [alice, bob],
+        demands: ["0x1111" as `0x${string}`, "0x2222" as `0x${string}`],
+      };
+
+      const anyEncoded = client.logicalArbiters.encodeAnyArbiterDemand(demand);
+      const allEncoded = client.logicalArbiters.encodeAllArbiterDemand(demand);
+      
+      // The encoding should be identical since they use the same struct
+      expect(anyEncoded).toBe(allEncoded);
+      
+      // Both should decode correctly with either decoder
+      const anyDecoded = client.logicalArbiters.decodeAnyArbiterDemand(anyEncoded);
+      const allDecoded = client.logicalArbiters.decodeAllArbiterDemand(allEncoded);
+      
+      expect(anyDecoded).toEqual(allDecoded);
+      expect(anyDecoded.arbiters).toEqual(demand.arbiters);
+      expect(anyDecoded.demands).toEqual(demand.demands);
+    });
+  });
+
+  describe("Error handling", () => {
+    test("should throw error for invalid hex data in AnyArbiter", () => {
+      const client = testContext.aliceClient;
+      
+      expect(() => {
+        client.logicalArbiters.decodeAnyArbiterDemand("invalid-hex" as `0x${string}`);
+      }).toThrow();
+    });
+
+    test("should throw error for invalid hex data in AllArbiter", () => {
+      const client = testContext.aliceClient;
+      
+      expect(() => {
+        client.logicalArbiters.decodeAllArbiterDemand("not-hex" as `0x${string}`);
+      }).toThrow();
+    });
+
+    test("should throw error for insufficient data", () => {
+      const client = testContext.aliceClient;
+      
+      expect(() => {
+        client.logicalArbiters.decodeAnyArbiterDemand("0x123" as `0x${string}`);
+      }).toThrow();
+      
+      expect(() => {
+        client.logicalArbiters.decodeAllArbiterDemand("0x456" as `0x${string}`);
+      }).toThrow();
+    });
+
+    test("should throw error for malformed addresses", () => {
+      const client = testContext.aliceClient;
+      
+      expect(() => {
+        client.logicalArbiters.encodeAnyArbiterDemand({
+          arbiters: ["invalid-address" as `0x${string}`],
+          demands: ["0x1234" as `0x${string}`],
+        });
+      }).toThrow();
+    });
+  });
+
+  describe("Integration with manual encoding", () => {
+    test("should produce same result as manual ABI encoding for AnyArbiter", () => {
+      const client = testContext.aliceClient;
+      
+      const demand = {
+        arbiters: [alice, bob],
+        demands: ["0x1234" as `0x${string}`, "0x5678" as `0x${string}`],
+      };
+      
+      // Manual encoding using viem directly
+      const manualEncoded = encodeAbiParameters(
+        parseAbiParameters("(address[] arbiters, bytes[] demands)"),
+        [demand]
+      );
+      
+      // SDK encoding
+      const sdkEncoded = client.logicalArbiters.encodeAnyArbiterDemand(demand);
+      
+      expect(sdkEncoded).toBe(manualEncoded);
+    });
+
+    test("should produce same result as manual ABI encoding for AllArbiter", () => {
+      const client = testContext.aliceClient;
+      
+      const demand = {
+        arbiters: [charlie],
+        demands: ["0xabcd" as `0x${string}`],
+      };
+      
+      // Manual encoding using viem directly
+      const manualEncoded = encodeAbiParameters(
+        parseAbiParameters("(address[] arbiters, bytes[] demands)"),
+        [demand]
+      );
+      
+      // SDK encoding
+      const sdkEncoded = client.logicalArbiters.encodeAllArbiterDemand(demand);
+      
+      expect(sdkEncoded).toBe(manualEncoded);
+    });
+  });
+
+  describe("Nested arbiters scenario", () => {
+    test("should handle nested AnyArbiter inside AllArbiter", () => {
+      const client = testContext.aliceClient;
+      
+      // First, create a demand for a nested AnyArbiter
+      const nestedAnyDemand = client.logicalArbiters.encodeAnyArbiterDemand({
+        arbiters: [alice, bob],
+        demands: ["0x1111" as `0x${string}`, "0x2222" as `0x${string}`],
+      });
+      
+      // Then use that as a demand in an AllArbiter
+      const allDemand = {
+        arbiters: [charlie, testContext.addresses.anyArbiter || charlie], // Use anyArbiter address if available
+        demands: ["0x3333" as `0x${string}`, nestedAnyDemand],
+      };
+      
+      const encoded = client.logicalArbiters.encodeAllArbiterDemand(allDemand);
+      const decoded = client.logicalArbiters.decodeAllArbiterDemand(encoded);
+      
+      expectAddressesEqual(decoded.arbiters, allDemand.arbiters);
+      expect(decoded.demands).toEqual(allDemand.demands);
+      
+      // Verify we can decode the nested demand
+      const nestedDecoded = client.logicalArbiters.decodeAnyArbiterDemand(decoded.demands[1]);
+      expectAddressesEqual(nestedDecoded.arbiters, [alice, bob]);
+      expect(nestedDecoded.demands).toEqual(["0x1111", "0x2222"]);
+    });
+
+    test("should handle nested AllArbiter inside AnyArbiter", () => {
+      const client = testContext.aliceClient;
+      
+      // First, create a demand for a nested AllArbiter
+      const nestedAllDemand = client.logicalArbiters.encodeAllArbiterDemand({
+        arbiters: [alice, bob, charlie],
+        demands: [
+          "0xaaaa" as `0x${string}`,
+          "0xbbbb" as `0x${string}`,
+          "0xcccc" as `0x${string}`,
+        ],
+      });
+      
+      // Then use that as a demand in an AnyArbiter
+      const anyDemand = {
+        arbiters: [alice, testContext.addresses.allArbiter || bob], // Use allArbiter address if available
+        demands: ["0x1234" as `0x${string}`, nestedAllDemand],
+      };
+      
+      const encoded = client.logicalArbiters.encodeAnyArbiterDemand(anyDemand);
+      const decoded = client.logicalArbiters.decodeAnyArbiterDemand(encoded);
+      
+      expectAddressesEqual(decoded.arbiters, anyDemand.arbiters);
+      expect(decoded.demands).toEqual(anyDemand.demands);
+      
+      // Verify we can decode the nested demand
+      const nestedDecoded = client.logicalArbiters.decodeAllArbiterDemand(decoded.demands[1]);
+      expectAddressesEqual(nestedDecoded.arbiters, [alice, bob, charlie]);
+      expect(nestedDecoded.demands).toEqual(["0xaaaa", "0xbbbb", "0xcccc"]);
+    });
+  });
+
+  describe("Real-world usage patterns", () => {
+    test("should handle typical multi-signature scenario", () => {
+      const client = testContext.aliceClient;
+      
+      // Create demands for multiple trusted party arbiters
+      const trusteeAddresses = [alice, bob, charlie];
+      const trusteeSignatures = [
+        "0x1111111111111111111111111111111111111111111111111111111111111111" as `0x${string}`,
+        "0x2222222222222222222222222222222222222222222222222222222222222222" as `0x${string}`,
+        "0x3333333333333333333333333333333333333333333333333333333333333333" as `0x${string}`,
+      ];
+      
+      // AllArbiter: Require all trustees to sign
+      const multiSigDemand = {
+        arbiters: trusteeAddresses,
+        demands: trusteeSignatures,
+      };
+      
+      const encoded = client.logicalArbiters.encodeAllArbiterDemand(multiSigDemand);
+      const decoded = client.logicalArbiters.decodeAllArbiterDemand(encoded);
+      
+      expect(decoded.arbiters).toEqual(trusteeAddresses);
+      expect(decoded.demands).toEqual(trusteeSignatures);
+    });
+
+    test("should handle fallback arbiter scenario", () => {
+      const client = testContext.aliceClient;
+      
+      // AnyArbiter: Primary arbiter or fallback arbiter
+      const fallbackDemand = {
+        arbiters: [alice, bob], // Primary: alice, Fallback: bob
+        demands: [
+          "0x1234567890abcdef" as `0x${string}`, // Primary demand
+          "0x" as `0x${string}`, // Fallback (empty demand)
+        ],
+      };
+      
+      const encoded = client.logicalArbiters.encodeAnyArbiterDemand(fallbackDemand);
+      const decoded = client.logicalArbiters.decodeAnyArbiterDemand(encoded);
+      
+      expect(decoded.arbiters).toEqual(fallbackDemand.arbiters);
+      expect(decoded.demands).toEqual(fallbackDemand.demands);
+    });
+  });
+});


### PR DESCRIPTION
### What I added:
- [x] Added SDK support for all attestation properties arbiters ( encode, decode)
- [x] Split arbiters.ts into attestation properties and logical arbiters
- [x] Added logical arbiters support (AnyArbiter, AllArbiter = 4 functions)
- [x] Written tests covering all new functionality. The list of implemented functions can be found at the beginning of the test files.
- [x] Verified all tests pass successfully