### PR TITLE
SDK Backlogs: requestArbitration and ABI Object json usage

### DIFF
--- a/src/clients/attestation.ts
+++ b/src/clients/attestation.ts
@@ -27,7 +27,7 @@ export const makeAttestationClient = (
   )?.outputs?.[0];
 
   // Fallback ABI structure for AttestationEscrowObligation
-  const attestationAbi = [
+  const fallbackAttestationAbi = [
     { name: "arbiter", type: "address", internalType: "address" },
     { name: "demand", type: "bytes", internalType: "bytes" },
     {
@@ -60,6 +60,12 @@ export const makeAttestationClient = (
       ],
     },
   ];
+
+  // Use ABI from contract if available, otherwise fallback to manual definition
+  const attestationAbi = escrowObligationDataType ? [escrowObligationDataType] : fallbackAttestationAbi;
+  const attestation2Abi = escrow2ObligationDataType ? [escrow2ObligationDataType] : parseAbiParameters(
+    "(address arbiter, bytes demand, bytes32 attestationUid)",
+  );
 
   const getEscrowSchema = async () =>
     await viemClient.readContract({
@@ -96,10 +102,7 @@ export const makeAttestationClient = (
       arbiter: `0x${string}`;
       demand: `0x${string}`;
     }) => {
-      return encodeAbiParameters(
-        escrowObligationDataType ? [escrowObligationDataType] : attestationAbi, 
-        [data]
-      );
+      return encodeAbiParameters(attestationAbi, [data]);
     },
     /**
      * Encodes AttestationEscrowObligation2.ObligationData to bytes.
@@ -111,12 +114,7 @@ export const makeAttestationClient = (
       arbiter: `0x${string}`;
       demand: `0x${string}`;
     }) => {
-      return encodeAbiParameters(
-        escrow2ObligationDataType ? [escrow2ObligationDataType] : parseAbiParameters(
-          "(address arbiter, bytes demand, bytes32 attestationUid)",
-        ),
-        [data],
-      );
+      return encodeAbiParameters(attestation2Abi, [data]);
     },
     /**
      * Decodes AttestationEscrowObligation.ObligationData from bytes.
@@ -124,10 +122,7 @@ export const makeAttestationClient = (
      * @returns the decoded ObligationData object
      */
     decodeEscrowObligation: (obligationData: `0x${string}`) => {
-      return decodeAbiParameters(
-        escrowObligationDataType ? [escrowObligationDataType] : attestationAbi, 
-        obligationData
-      )[0];
+      return decodeAbiParameters(attestationAbi, obligationData)[0];
     },
     /**
      * Decodes AttestationEscrowObligation2.ObligationData from bytes.
@@ -135,12 +130,7 @@ export const makeAttestationClient = (
      * @returns the decoded ObligationData object
      */
     decodeEscrow2Obligation: (obligationData: `0x${string}`) => {
-      return decodeAbiParameters(
-        escrow2ObligationDataType ? [escrow2ObligationDataType] : parseAbiParameters(
-          "(address arbiter, bytes demand, bytes32 attestationUid)",
-        ),
-        obligationData,
-      )[0];
+      return decodeAbiParameters(attestation2Abi, obligationData)[0];
     },
     getEscrowSchema,
     getEscrow2Schema,
@@ -158,10 +148,7 @@ export const makeAttestationClient = (
       if (attestation.schema !== schema) {
         throw new Error(`Unsupported schema: ${attestation.schema}`);
       }
-      const data = decodeAbiParameters(
-        escrowObligationDataType ? [escrowObligationDataType] : attestationAbi,
-        attestation.data,
-      )[0];
+      const data = decodeAbiParameters(attestationAbi, attestation.data)[0];
 
       return {
         ...attestation,
@@ -177,12 +164,7 @@ export const makeAttestationClient = (
       if (attestation.schema !== schema) {
         throw new Error(`Unsupported schema: ${attestation.schema}`);
       }
-      const data = decodeAbiParameters(
-        escrow2ObligationDataType ? [escrow2ObligationDataType] : parseAbiParameters(
-          "(address arbiter, bytes demand, bytes32 attestationUid)",
-        ),
-        attestation.data,
-      )[0];
+      const data = decodeAbiParameters(attestation2Abi, attestation.data)[0];
 
       return {
         ...attestation,

--- a/src/clients/attestation.ts
+++ b/src/clients/attestation.ts
@@ -26,46 +26,18 @@ export const makeAttestationClient = (
     (item) => item.type === "function" && item.name === "decodeObligationData"
   )?.outputs?.[0];
 
-  // Fallback ABI structure for AttestationEscrowObligation
-  const fallbackAttestationAbi = [
-    { name: "arbiter", type: "address", internalType: "address" },
-    { name: "demand", type: "bytes", internalType: "bytes" },
-    {
-      name: "attestation",
-      type: "tuple",
-      internalType: "struct AttestationRequest",
-      components: [
-        { name: "schema", type: "bytes32", internalType: "bytes32" },
-        {
-          name: "data",
-          type: "tuple",
-          internalType: "struct AttestationRequestData",
-          components: [
-            {
-              name: "recipient",
-              type: "address",
-              internalType: "address",
-            },
-            {
-              name: "expirationTime",
-              type: "uint64",
-              internalType: "uint64",
-            },
-            { name: "revocable", type: "bool", internalType: "bool" },
-            { name: "refUID", type: "bytes32", internalType: "bytes32" },
-            { name: "data", type: "bytes", internalType: "bytes" },
-            { name: "value", type: "uint256", internalType: "uint256" },
-          ],
-        },
-      ],
-    },
-  ];
+  // Ensure ABI extraction succeeded - fail fast if contract JSONs are malformed
+  if (!escrowObligationDataType) {
+    throw new Error('Failed to extract ABI type from AttestationEscrowObligation contract JSON. The contract definition may be missing or malformed.');
+  }
 
-  // Use ABI from contract if available, otherwise fallback to manual definition
-  const attestationAbi = escrowObligationDataType ? [escrowObligationDataType] : fallbackAttestationAbi;
-  const attestation2Abi = escrow2ObligationDataType ? [escrow2ObligationDataType] : parseAbiParameters(
-    "(address arbiter, bytes demand, bytes32 attestationUid)",
-  );
+  if (!escrow2ObligationDataType) {
+    throw new Error('Failed to extract ABI type from AttestationEscrowObligation2 contract JSON. The contract definition may be missing or malformed.');
+  }
+
+  // Use contract ABIs directly
+  const attestationAbi = [escrowObligationDataType];
+  const attestation2Abi = [escrow2ObligationDataType];
 
   const getEscrowSchema = async () =>
     await viemClient.readContract({

--- a/src/clients/attestationPropertiesArbiters.ts
+++ b/src/clients/attestationPropertiesArbiters.ts
@@ -6,6 +6,32 @@ import {
 import type { ViemClient } from "../utils";
 import type { ChainAddresses } from "../types";
 
+// Import all attestation properties arbiter ABIs
+import { abi as AttesterArbiterComposingAbi } from "../contracts/AttesterArbiterComposing";
+import { abi as AttesterArbiterNonComposingAbi } from "../contracts/AttesterArbiterNonComposing";
+import { abi as TimeAfterArbiterComposingAbi } from "../contracts/TimeAfterArbiterComposing";
+import { abi as TimeAfterArbiterNonComposingAbi } from "../contracts/TimeAfterArbiterNonComposing";
+import { abi as TimeBeforeArbiterComposingAbi } from "../contracts/TimeBeforeArbiterComposing";
+import { abi as TimeBeforeArbiterNonComposingAbi } from "../contracts/TimeBeforeArbiterNonComposing";
+import { abi as TimeEqualArbiterComposingAbi } from "../contracts/TimeEqualArbiterComposing";
+import { abi as TimeEqualArbiterNonComposingAbi } from "../contracts/TimeEqualArbiterNonComposing";
+import { abi as ExpirationTimeAfterArbiterComposingAbi } from "../contracts/ExpirationTimeAfterArbiterComposing";
+import { abi as ExpirationTimeAfterArbiterNonComposingAbi } from "../contracts/ExpirationTimeAfterArbiterNonComposing";
+import { abi as ExpirationTimeBeforeArbiterComposingAbi } from "../contracts/ExpirationTimeBeforeArbiterComposing";
+import { abi as ExpirationTimeBeforeArbiterNonComposingAbi } from "../contracts/ExpirationTimeBeforeArbiterNonComposing";
+import { abi as ExpirationTimeEqualArbiterComposingAbi } from "../contracts/ExpirationTimeEqualArbiterComposing";
+import { abi as ExpirationTimeEqualArbiterNonComposingAbi } from "../contracts/ExpirationTimeEqualArbiterNonComposing";
+import { abi as RecipientArbiterComposingAbi } from "../contracts/RecipientArbiterComposing";
+import { abi as RecipientArbiterNonComposingAbi } from "../contracts/RecipientArbiterNonComposing";
+import { abi as RefUidArbiterComposingAbi } from "../contracts/RefUidArbiterComposing";
+import { abi as RefUidArbiterNonComposingAbi } from "../contracts/RefUidArbiterNonComposing";
+import { abi as RevocableArbiterComposingAbi } from "../contracts/RevocableArbiterComposing";
+import { abi as RevocableArbiterNonComposingAbi } from "../contracts/RevocableArbiterNonComposing";
+import { abi as SchemaArbiterComposingAbi } from "../contracts/SchemaArbiterComposing";
+import { abi as SchemaArbiterNonComposingAbi } from "../contracts/SchemaArbiterNonComposing";
+import { abi as UidArbiterComposingAbi } from "../contracts/UidArbiterComposing";
+import { abi as UidArbiterNonComposingAbi } from "../contracts/UidArbiterNonComposing";
+
 /**
  * Attestation Properties Arbiters Client
  * 
@@ -28,6 +54,80 @@ export const makeAttestationPropertiesArbitersClient = (
   viemClient: ViemClient,
   addresses: ChainAddresses,
 ) => {
+  // Extract DemandData struct ABI from contract ABIs
+  const attesterArbiterComposingDemandDataType = (AttesterArbiterComposingAbi.find(
+    (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
+  ) as { outputs: readonly any[] } | undefined)?.outputs?.[0];
+  const attesterArbiterNonComposingDemandDataType = (AttesterArbiterNonComposingAbi.find(
+    (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
+  ) as { outputs: readonly any[] } | undefined)?.outputs?.[0];
+  const timeAfterArbiterComposingDemandDataType = (TimeAfterArbiterComposingAbi.find(
+    (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
+  ) as { outputs: readonly any[] } | undefined)?.outputs?.[0];
+  const timeAfterArbiterNonComposingDemandDataType = (TimeAfterArbiterNonComposingAbi.find(
+    (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
+  ) as { outputs: readonly any[] } | undefined)?.outputs?.[0];
+  const timeBeforeArbiterComposingDemandDataType = (TimeBeforeArbiterComposingAbi.find(
+    (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
+  ) as { outputs: readonly any[] } | undefined)?.outputs?.[0];
+  const timeBeforeArbiterNonComposingDemandDataType = (TimeBeforeArbiterNonComposingAbi.find(
+    (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
+  ) as { outputs: readonly any[] } | undefined)?.outputs?.[0];
+  const timeEqualArbiterComposingDemandDataType = (TimeEqualArbiterComposingAbi.find(
+    (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
+  ) as { outputs: readonly any[] } | undefined)?.outputs?.[0];
+  const timeEqualArbiterNonComposingDemandDataType = (TimeEqualArbiterNonComposingAbi.find(
+    (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
+  ) as { outputs: readonly any[] } | undefined)?.outputs?.[0];
+  const expirationTimeAfterArbiterComposingDemandDataType = (ExpirationTimeAfterArbiterComposingAbi.find(
+    (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
+  ) as { outputs: readonly any[] } | undefined)?.outputs?.[0];
+  const expirationTimeAfterArbiterNonComposingDemandDataType = (ExpirationTimeAfterArbiterNonComposingAbi.find(
+    (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
+  ) as { outputs: readonly any[] } | undefined)?.outputs?.[0];
+  const expirationTimeBeforeArbiterComposingDemandDataType = (ExpirationTimeBeforeArbiterComposingAbi.find(
+    (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
+  ) as { outputs: readonly any[] } | undefined)?.outputs?.[0];
+  const expirationTimeBeforeArbiterNonComposingDemandDataType = (ExpirationTimeBeforeArbiterNonComposingAbi.find(
+    (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
+  ) as { outputs: readonly any[] } | undefined)?.outputs?.[0];
+  const expirationTimeEqualArbiterComposingDemandDataType = (ExpirationTimeEqualArbiterComposingAbi.find(
+    (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
+  ) as { outputs: readonly any[] } | undefined)?.outputs?.[0];
+  const expirationTimeEqualArbiterNonComposingDemandDataType = (ExpirationTimeEqualArbiterNonComposingAbi.find(
+    (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
+  ) as { outputs: readonly any[] } | undefined)?.outputs?.[0];
+  const recipientArbiterComposingDemandDataType = (RecipientArbiterComposingAbi.find(
+    (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
+  ) as { outputs: readonly any[] } | undefined)?.outputs?.[0];
+  const recipientArbiterNonComposingDemandDataType = (RecipientArbiterNonComposingAbi.find(
+    (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
+  ) as { outputs: readonly any[] } | undefined)?.outputs?.[0];
+  const refUidArbiterComposingDemandDataType = (RefUidArbiterComposingAbi.find(
+    (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
+  ) as { outputs: readonly any[] } | undefined)?.outputs?.[0];
+  const refUidArbiterNonComposingDemandDataType = (RefUidArbiterNonComposingAbi.find(
+    (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
+  ) as { outputs: readonly any[] } | undefined)?.outputs?.[0];
+  const revocableArbiterComposingDemandDataType = (RevocableArbiterComposingAbi.find(
+    (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
+  ) as { outputs: readonly any[] } | undefined)?.outputs?.[0];
+  const revocableArbiterNonComposingDemandDataType = (RevocableArbiterNonComposingAbi.find(
+    (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
+  ) as { outputs: readonly any[] } | undefined)?.outputs?.[0];
+  const schemaArbiterComposingDemandDataType = (SchemaArbiterComposingAbi.find(
+    (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
+  ) as { outputs: readonly any[] } | undefined)?.outputs?.[0];
+  const schemaArbiterNonComposingDemandDataType = (SchemaArbiterNonComposingAbi.find(
+    (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
+  ) as { outputs: readonly any[] } | undefined)?.outputs?.[0];
+  const uidArbiterComposingDemandDataType = (UidArbiterComposingAbi.find(
+    (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
+  ) as { outputs: readonly any[] } | undefined)?.outputs?.[0];
+  const uidArbiterNonComposingDemandDataType = (UidArbiterNonComposingAbi.find(
+    (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
+  ) as { outputs: readonly any[] } | undefined)?.outputs?.[0];
+
   return {
     // Attester Arbiters
     /**
@@ -40,7 +140,7 @@ export const makeAttestationPropertiesArbitersClient = (
       attester: `0x${string}`;
     }) => {
       return encodeAbiParameters(
-        parseAbiParameters("(address baseArbiter, bytes baseDemand, address attester)"),
+        attesterArbiterComposingDemandDataType ? [attesterArbiterComposingDemandDataType] : parseAbiParameters("(address baseArbiter, bytes baseDemand, address attester)"),
         [demand],
       );
     },
@@ -50,7 +150,7 @@ export const makeAttestationPropertiesArbitersClient = (
      */
     decodeAttesterArbiterComposingDemand: (demandData: `0x${string}`) => {
       return decodeAbiParameters(
-        parseAbiParameters("(address baseArbiter, bytes baseDemand, address attester)"),
+        attesterArbiterComposingDemandDataType ? [attesterArbiterComposingDemandDataType] : parseAbiParameters("(address baseArbiter, bytes baseDemand, address attester)"),
         demandData,
       )[0];
     },
@@ -63,7 +163,7 @@ export const makeAttestationPropertiesArbitersClient = (
       attester: `0x${string}`;
     }) => {
       return encodeAbiParameters(
-        parseAbiParameters("(address attester)"),
+        attesterArbiterNonComposingDemandDataType ? [attesterArbiterNonComposingDemandDataType] : parseAbiParameters("(address attester)"),
         [demand],
       );
     },
@@ -73,7 +173,7 @@ export const makeAttestationPropertiesArbitersClient = (
      */
     decodeAttesterArbiterNonComposingDemand: (demandData: `0x${string}`) => {
       return decodeAbiParameters(
-        parseAbiParameters("(address attester)"),
+        attesterArbiterNonComposingDemandDataType ? [attesterArbiterNonComposingDemandDataType] : parseAbiParameters("(address attester)"),
         demandData,
       )[0];
     },
@@ -89,7 +189,7 @@ export const makeAttestationPropertiesArbitersClient = (
       time: bigint;
     }) => {
       return encodeAbiParameters(
-        parseAbiParameters("(address baseArbiter, bytes baseDemand, uint64 time)"),
+        timeAfterArbiterComposingDemandDataType ? [timeAfterArbiterComposingDemandDataType] : parseAbiParameters("(address baseArbiter, bytes baseDemand, uint64 time)"),
         [demand],
       );
     },
@@ -99,7 +199,7 @@ export const makeAttestationPropertiesArbitersClient = (
      */
     decodeTimeAfterArbiterComposingDemand: (demandData: `0x${string}`) => {
       return decodeAbiParameters(
-        parseAbiParameters("(address baseArbiter, bytes baseDemand, uint64 time)"),
+        timeAfterArbiterComposingDemandDataType ? [timeAfterArbiterComposingDemandDataType] : parseAbiParameters("(address baseArbiter, bytes baseDemand, uint64 time)"),
         demandData,
       )[0];
     },
@@ -112,7 +212,7 @@ export const makeAttestationPropertiesArbitersClient = (
       time: bigint;
     }) => {
       return encodeAbiParameters(
-        parseAbiParameters("(uint64 time)"),
+        timeAfterArbiterNonComposingDemandDataType ? [timeAfterArbiterNonComposingDemandDataType] : parseAbiParameters("(uint64 time)"),
         [demand],
       );
     },
@@ -122,7 +222,7 @@ export const makeAttestationPropertiesArbitersClient = (
      */
     decodeTimeAfterArbiterNonComposingDemand: (demandData: `0x${string}`) => {
       return decodeAbiParameters(
-        parseAbiParameters("(uint64 time)"),
+        timeAfterArbiterNonComposingDemandDataType ? [timeAfterArbiterNonComposingDemandDataType] : parseAbiParameters("(uint64 time)"),
         demandData,
       )[0];
     },
@@ -138,7 +238,7 @@ export const makeAttestationPropertiesArbitersClient = (
       time: bigint;
     }) => {
       return encodeAbiParameters(
-        parseAbiParameters("(address baseArbiter, bytes baseDemand, uint64 time)"),
+        timeBeforeArbiterComposingDemandDataType ? [timeBeforeArbiterComposingDemandDataType] : parseAbiParameters("(address baseArbiter, bytes baseDemand, uint64 time)"),
         [demand],
       );
     },
@@ -148,7 +248,7 @@ export const makeAttestationPropertiesArbitersClient = (
      */
     decodeTimeBeforeArbiterComposingDemand: (demandData: `0x${string}`) => {
       return decodeAbiParameters(
-        parseAbiParameters("(address baseArbiter, bytes baseDemand, uint64 time)"),
+        timeBeforeArbiterComposingDemandDataType ? [timeBeforeArbiterComposingDemandDataType] : parseAbiParameters("(address baseArbiter, bytes baseDemand, uint64 time)"),
         demandData,
       )[0];
     },
@@ -161,7 +261,7 @@ export const makeAttestationPropertiesArbitersClient = (
       time: bigint;
     }) => {
       return encodeAbiParameters(
-        parseAbiParameters("(uint64 time)"),
+        timeBeforeArbiterNonComposingDemandDataType ? [timeBeforeArbiterNonComposingDemandDataType] : parseAbiParameters("(uint64 time)"),
         [demand],
       );
     },
@@ -171,7 +271,7 @@ export const makeAttestationPropertiesArbitersClient = (
      */
     decodeTimeBeforeArbiterNonComposingDemand: (demandData: `0x${string}`) => {
       return decodeAbiParameters(
-        parseAbiParameters("(uint64 time)"),
+        timeBeforeArbiterNonComposingDemandDataType ? [timeBeforeArbiterNonComposingDemandDataType] : parseAbiParameters("(uint64 time)"),
         demandData,
       )[0];
     },
@@ -187,7 +287,7 @@ export const makeAttestationPropertiesArbitersClient = (
       time: bigint;
     }) => {
       return encodeAbiParameters(
-        parseAbiParameters("(address baseArbiter, bytes baseDemand, uint64 time)"),
+        timeEqualArbiterComposingDemandDataType ? [timeEqualArbiterComposingDemandDataType] : parseAbiParameters("(address baseArbiter, bytes baseDemand, uint64 time)"),
         [demand],
       );
     },
@@ -197,7 +297,7 @@ export const makeAttestationPropertiesArbitersClient = (
      */
     decodeTimeEqualArbiterComposingDemand: (demandData: `0x${string}`) => {
       return decodeAbiParameters(
-        parseAbiParameters("(address baseArbiter, bytes baseDemand, uint64 time)"),
+        timeEqualArbiterComposingDemandDataType ? [timeEqualArbiterComposingDemandDataType] : parseAbiParameters("(address baseArbiter, bytes baseDemand, uint64 time)"),
         demandData,
       )[0];
     },
@@ -210,7 +310,7 @@ export const makeAttestationPropertiesArbitersClient = (
       time: bigint;
     }) => {
       return encodeAbiParameters(
-        parseAbiParameters("(uint64 time)"),
+        timeEqualArbiterNonComposingDemandDataType ? [timeEqualArbiterNonComposingDemandDataType] : parseAbiParameters("(uint64 time)"),
         [demand],
       );
     },
@@ -220,7 +320,7 @@ export const makeAttestationPropertiesArbitersClient = (
      */
     decodeTimeEqualArbiterNonComposingDemand: (demandData: `0x${string}`) => {
       return decodeAbiParameters(
-        parseAbiParameters("(uint64 time)"),
+        timeEqualArbiterNonComposingDemandDataType ? [timeEqualArbiterNonComposingDemandDataType] : parseAbiParameters("(uint64 time)"),
         demandData,
       )[0];
     },
@@ -236,7 +336,7 @@ export const makeAttestationPropertiesArbitersClient = (
       expirationTime: bigint;
     }) => {
       return encodeAbiParameters(
-        parseAbiParameters("(address baseArbiter, bytes baseDemand, uint64 expirationTime)"),
+        expirationTimeAfterArbiterComposingDemandDataType ? [expirationTimeAfterArbiterComposingDemandDataType] : parseAbiParameters("(address baseArbiter, bytes baseDemand, uint64 expirationTime)"),
         [demand],
       );
     },
@@ -246,7 +346,7 @@ export const makeAttestationPropertiesArbitersClient = (
      */
     decodeExpirationTimeAfterArbiterComposingDemand: (demandData: `0x${string}`) => {
       return decodeAbiParameters(
-        parseAbiParameters("(address baseArbiter, bytes baseDemand, uint64 expirationTime)"),
+        expirationTimeAfterArbiterComposingDemandDataType ? [expirationTimeAfterArbiterComposingDemandDataType] : parseAbiParameters("(address baseArbiter, bytes baseDemand, uint64 expirationTime)"),
         demandData,
       )[0];
     },
@@ -259,7 +359,7 @@ export const makeAttestationPropertiesArbitersClient = (
       expirationTime: bigint;
     }) => {
       return encodeAbiParameters(
-        parseAbiParameters("(uint64 expirationTime)"),
+        expirationTimeAfterArbiterNonComposingDemandDataType ? [expirationTimeAfterArbiterNonComposingDemandDataType] : parseAbiParameters("(uint64 expirationTime)"),
         [demand],
       );
     },
@@ -269,7 +369,7 @@ export const makeAttestationPropertiesArbitersClient = (
      */
     decodeExpirationTimeAfterArbiterNonComposingDemand: (demandData: `0x${string}`) => {
       return decodeAbiParameters(
-        parseAbiParameters("(uint64 expirationTime)"),
+        expirationTimeAfterArbiterNonComposingDemandDataType ? [expirationTimeAfterArbiterNonComposingDemandDataType] : parseAbiParameters("(uint64 expirationTime)"),
         demandData,
       )[0];
     },
@@ -285,7 +385,7 @@ export const makeAttestationPropertiesArbitersClient = (
       expirationTime: bigint;
     }) => {
       return encodeAbiParameters(
-        parseAbiParameters("(address baseArbiter, bytes baseDemand, uint64 expirationTime)"),
+        expirationTimeBeforeArbiterComposingDemandDataType ? [expirationTimeBeforeArbiterComposingDemandDataType] : parseAbiParameters("(address baseArbiter, bytes baseDemand, uint64 expirationTime)"),
         [demand],
       );
     },
@@ -295,7 +395,7 @@ export const makeAttestationPropertiesArbitersClient = (
      */
     decodeExpirationTimeBeforeArbiterComposingDemand: (demandData: `0x${string}`) => {
       return decodeAbiParameters(
-        parseAbiParameters("(address baseArbiter, bytes baseDemand, uint64 expirationTime)"),
+        expirationTimeBeforeArbiterComposingDemandDataType ? [expirationTimeBeforeArbiterComposingDemandDataType] : parseAbiParameters("(address baseArbiter, bytes baseDemand, uint64 expirationTime)"),
         demandData,
       )[0];
     },
@@ -308,7 +408,7 @@ export const makeAttestationPropertiesArbitersClient = (
       expirationTime: bigint;
     }) => {
       return encodeAbiParameters(
-        parseAbiParameters("(uint64 expirationTime)"),
+        expirationTimeBeforeArbiterNonComposingDemandDataType ? [expirationTimeBeforeArbiterNonComposingDemandDataType] : parseAbiParameters("(uint64 expirationTime)"),
         [demand],
       );
     },
@@ -318,7 +418,7 @@ export const makeAttestationPropertiesArbitersClient = (
      */
     decodeExpirationTimeBeforeArbiterNonComposingDemand: (demandData: `0x${string}`) => {
       return decodeAbiParameters(
-        parseAbiParameters("(uint64 expirationTime)"),
+        expirationTimeBeforeArbiterNonComposingDemandDataType ? [expirationTimeBeforeArbiterNonComposingDemandDataType] : parseAbiParameters("(uint64 expirationTime)"),
         demandData,
       )[0];
     },
@@ -334,7 +434,7 @@ export const makeAttestationPropertiesArbitersClient = (
       expirationTime: bigint;
     }) => {
       return encodeAbiParameters(
-        parseAbiParameters("(address baseArbiter, bytes baseDemand, uint64 expirationTime)"),
+        expirationTimeEqualArbiterComposingDemandDataType ? [expirationTimeEqualArbiterComposingDemandDataType] : parseAbiParameters("(address baseArbiter, bytes baseDemand, uint64 expirationTime)"),
         [demand],
       );
     },
@@ -344,7 +444,7 @@ export const makeAttestationPropertiesArbitersClient = (
      */
     decodeExpirationTimeEqualArbiterComposingDemand: (demandData: `0x${string}`) => {
       return decodeAbiParameters(
-        parseAbiParameters("(address baseArbiter, bytes baseDemand, uint64 expirationTime)"),
+        expirationTimeEqualArbiterComposingDemandDataType ? [expirationTimeEqualArbiterComposingDemandDataType] : parseAbiParameters("(address baseArbiter, bytes baseDemand, uint64 expirationTime)"),
         demandData,
       )[0];
     },
@@ -357,7 +457,7 @@ export const makeAttestationPropertiesArbitersClient = (
       expirationTime: bigint;
     }) => {
       return encodeAbiParameters(
-        parseAbiParameters("(uint64 expirationTime)"),
+        expirationTimeEqualArbiterNonComposingDemandDataType ? [expirationTimeEqualArbiterNonComposingDemandDataType] : parseAbiParameters("(uint64 expirationTime)"),
         [demand],
       );
     },
@@ -367,7 +467,7 @@ export const makeAttestationPropertiesArbitersClient = (
      */
     decodeExpirationTimeEqualArbiterNonComposingDemand: (demandData: `0x${string}`) => {
       return decodeAbiParameters(
-        parseAbiParameters("(uint64 expirationTime)"),
+        expirationTimeEqualArbiterNonComposingDemandDataType ? [expirationTimeEqualArbiterNonComposingDemandDataType] : parseAbiParameters("(uint64 expirationTime)"),
         demandData,
       )[0];
     },
@@ -383,7 +483,7 @@ export const makeAttestationPropertiesArbitersClient = (
       recipient: `0x${string}`;
     }) => {
       return encodeAbiParameters(
-        parseAbiParameters("(address baseArbiter, bytes baseDemand, address recipient)"),
+        recipientArbiterComposingDemandDataType ? [recipientArbiterComposingDemandDataType] : parseAbiParameters("(address baseArbiter, bytes baseDemand, address recipient)"),
         [demand],
       );
     },
@@ -393,7 +493,7 @@ export const makeAttestationPropertiesArbitersClient = (
      */
     decodeRecipientArbiterComposingDemand: (demandData: `0x${string}`) => {
       return decodeAbiParameters(
-        parseAbiParameters("(address baseArbiter, bytes baseDemand, address recipient)"),
+        recipientArbiterComposingDemandDataType ? [recipientArbiterComposingDemandDataType] : parseAbiParameters("(address baseArbiter, bytes baseDemand, address recipient)"),
         demandData,
       )[0];
     },
@@ -406,7 +506,7 @@ export const makeAttestationPropertiesArbitersClient = (
       recipient: `0x${string}`;
     }) => {
       return encodeAbiParameters(
-        parseAbiParameters("(address recipient)"),
+        recipientArbiterNonComposingDemandDataType ? [recipientArbiterNonComposingDemandDataType] : parseAbiParameters("(address recipient)"),
         [demand],
       );
     },
@@ -416,7 +516,7 @@ export const makeAttestationPropertiesArbitersClient = (
      */
     decodeRecipientArbiterNonComposingDemand: (demandData: `0x${string}`) => {
       return decodeAbiParameters(
-        parseAbiParameters("(address recipient)"),
+        recipientArbiterNonComposingDemandDataType ? [recipientArbiterNonComposingDemandDataType] : parseAbiParameters("(address recipient)"),
         demandData,
       )[0];
     },
@@ -432,7 +532,7 @@ export const makeAttestationPropertiesArbitersClient = (
       refUID: `0x${string}`;
     }) => {
       return encodeAbiParameters(
-        parseAbiParameters("(address baseArbiter, bytes baseDemand, bytes32 refUID)"),
+        refUidArbiterComposingDemandDataType ? [refUidArbiterComposingDemandDataType] : parseAbiParameters("(address baseArbiter, bytes baseDemand, bytes32 refUID)"),
         [demand],
       );
     },
@@ -442,7 +542,7 @@ export const makeAttestationPropertiesArbitersClient = (
      */
     decodeRefUidArbiterComposingDemand: (demandData: `0x${string}`) => {
       return decodeAbiParameters(
-        parseAbiParameters("(address baseArbiter, bytes baseDemand, bytes32 refUID)"),
+        refUidArbiterComposingDemandDataType ? [refUidArbiterComposingDemandDataType] : parseAbiParameters("(address baseArbiter, bytes baseDemand, bytes32 refUID)"),
         demandData,
       )[0];
     },
@@ -455,7 +555,7 @@ export const makeAttestationPropertiesArbitersClient = (
       refUID: `0x${string}`;
     }) => {
       return encodeAbiParameters(
-        parseAbiParameters("(bytes32 refUID)"),
+        refUidArbiterNonComposingDemandDataType ? [refUidArbiterNonComposingDemandDataType] : parseAbiParameters("(bytes32 refUID)"),
         [demand],
       );
     },
@@ -465,7 +565,7 @@ export const makeAttestationPropertiesArbitersClient = (
      */
     decodeRefUidArbiterNonComposingDemand: (demandData: `0x${string}`) => {
       return decodeAbiParameters(
-        parseAbiParameters("(bytes32 refUID)"),
+        refUidArbiterNonComposingDemandDataType ? [refUidArbiterNonComposingDemandDataType] : parseAbiParameters("(bytes32 refUID)"),
         demandData,
       )[0];
     },
@@ -481,7 +581,7 @@ export const makeAttestationPropertiesArbitersClient = (
       revocable: boolean;
     }) => {
       return encodeAbiParameters(
-        parseAbiParameters("(address baseArbiter, bytes baseDemand, bool revocable)"),
+        revocableArbiterComposingDemandDataType ? [revocableArbiterComposingDemandDataType] : parseAbiParameters("(address baseArbiter, bytes baseDemand, bool revocable)"),
         [demand],
       );
     },
@@ -491,7 +591,7 @@ export const makeAttestationPropertiesArbitersClient = (
      */
     decodeRevocableArbiterComposingDemand: (demandData: `0x${string}`) => {
       return decodeAbiParameters(
-        parseAbiParameters("(address baseArbiter, bytes baseDemand, bool revocable)"),
+        revocableArbiterComposingDemandDataType ? [revocableArbiterComposingDemandDataType] : parseAbiParameters("(address baseArbiter, bytes baseDemand, bool revocable)"),
         demandData,
       )[0];
     },
@@ -504,7 +604,7 @@ export const makeAttestationPropertiesArbitersClient = (
       revocable: boolean;
     }) => {
       return encodeAbiParameters(
-        parseAbiParameters("(bool revocable)"),
+        revocableArbiterNonComposingDemandDataType ? [revocableArbiterNonComposingDemandDataType] : parseAbiParameters("(bool revocable)"),
         [demand],
       );
     },
@@ -514,7 +614,7 @@ export const makeAttestationPropertiesArbitersClient = (
      */
     decodeRevocableArbiterNonComposingDemand: (demandData: `0x${string}`) => {
       return decodeAbiParameters(
-        parseAbiParameters("(bool revocable)"),
+        revocableArbiterNonComposingDemandDataType ? [revocableArbiterNonComposingDemandDataType] : parseAbiParameters("(bool revocable)"),
         demandData,
       )[0];
     },
@@ -530,7 +630,7 @@ export const makeAttestationPropertiesArbitersClient = (
       schema: `0x${string}`;
     }) => {
       return encodeAbiParameters(
-        parseAbiParameters("(address baseArbiter, bytes baseDemand, bytes32 schema)"),
+        schemaArbiterComposingDemandDataType ? [schemaArbiterComposingDemandDataType] : parseAbiParameters("(address baseArbiter, bytes baseDemand, bytes32 schema)"),
         [demand],
       );
     },
@@ -540,7 +640,7 @@ export const makeAttestationPropertiesArbitersClient = (
      */
     decodeSchemaArbiterComposingDemand: (demandData: `0x${string}`) => {
       return decodeAbiParameters(
-        parseAbiParameters("(address baseArbiter, bytes baseDemand, bytes32 schema)"),
+        schemaArbiterComposingDemandDataType ? [schemaArbiterComposingDemandDataType] : parseAbiParameters("(address baseArbiter, bytes baseDemand, bytes32 schema)"),
         demandData,
       )[0];
     },
@@ -553,7 +653,7 @@ export const makeAttestationPropertiesArbitersClient = (
       schema: `0x${string}`;
     }) => {
       return encodeAbiParameters(
-        parseAbiParameters("(bytes32 schema)"),
+        schemaArbiterNonComposingDemandDataType ? [schemaArbiterNonComposingDemandDataType] : parseAbiParameters("(bytes32 schema)"),
         [demand],
       );
     },
@@ -563,7 +663,7 @@ export const makeAttestationPropertiesArbitersClient = (
      */
     decodeSchemaArbiterNonComposingDemand: (demandData: `0x${string}`) => {
       return decodeAbiParameters(
-        parseAbiParameters("(bytes32 schema)"),
+        schemaArbiterNonComposingDemandDataType ? [schemaArbiterNonComposingDemandDataType] : parseAbiParameters("(bytes32 schema)"),
         demandData,
       )[0];
     },
@@ -579,7 +679,7 @@ export const makeAttestationPropertiesArbitersClient = (
       uid: `0x${string}`;
     }) => {
       return encodeAbiParameters(
-        parseAbiParameters("(address baseArbiter, bytes baseDemand, bytes32 uid)"),
+        uidArbiterComposingDemandDataType ? [uidArbiterComposingDemandDataType] : parseAbiParameters("(address baseArbiter, bytes baseDemand, bytes32 uid)"),
         [demand],
       );
     },
@@ -589,7 +689,7 @@ export const makeAttestationPropertiesArbitersClient = (
      */
     decodeUidArbiterComposingDemand: (demandData: `0x${string}`) => {
       return decodeAbiParameters(
-        parseAbiParameters("(address baseArbiter, bytes baseDemand, bytes32 uid)"),
+        uidArbiterComposingDemandDataType ? [uidArbiterComposingDemandDataType] : parseAbiParameters("(address baseArbiter, bytes baseDemand, bytes32 uid)"),
         demandData,
       )[0];
     },
@@ -602,7 +702,7 @@ export const makeAttestationPropertiesArbitersClient = (
       uid: `0x${string}`;
     }) => {
       return encodeAbiParameters(
-        parseAbiParameters("(bytes32 uid)"),
+        uidArbiterNonComposingDemandDataType ? [uidArbiterNonComposingDemandDataType] : parseAbiParameters("(bytes32 uid)"),
         [demand],
       );
     },
@@ -612,7 +712,7 @@ export const makeAttestationPropertiesArbitersClient = (
      */
     decodeUidArbiterNonComposingDemand: (demandData: `0x${string}`) => {
       return decodeAbiParameters(
-        parseAbiParameters("(bytes32 uid)"),
+        uidArbiterNonComposingDemandDataType ? [uidArbiterNonComposingDemandDataType] : parseAbiParameters("(bytes32 uid)"),
         demandData,
       )[0];
     },

--- a/src/clients/attestationPropertiesArbiters.ts
+++ b/src/clients/attestationPropertiesArbiters.ts
@@ -1,7 +1,6 @@
 import {
   decodeAbiParameters,
   encodeAbiParameters,
-  parseAbiParameters,
 } from "viem";
 import type { ViemClient } from "../utils";
 import type { ChainAddresses } from "../types";
@@ -32,6 +31,180 @@ import { abi as SchemaArbiterNonComposingAbi } from "../contracts/SchemaArbiterN
 import { abi as UidArbiterComposingAbi } from "../contracts/UidArbiterComposing";
 import { abi as UidArbiterNonComposingAbi } from "../contracts/UidArbiterNonComposing";
 
+// Extract DemandData struct ABIs from contract ABIs at module initialization
+const attesterArbiterComposingDecodeDemandFunction = AttesterArbiterComposingAbi.find(
+  (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
+);
+const attesterArbiterNonComposingDecodeDemandFunction = AttesterArbiterNonComposingAbi.find(
+  (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
+);
+const timeAfterArbiterComposingDecodeDemandFunction = TimeAfterArbiterComposingAbi.find(
+  (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
+);
+const timeAfterArbiterNonComposingDecodeDemandFunction = TimeAfterArbiterNonComposingAbi.find(
+  (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
+);
+const timeBeforeArbiterComposingDecodeDemandFunction = TimeBeforeArbiterComposingAbi.find(
+  (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
+);
+const timeBeforeArbiterNonComposingDecodeDemandFunction = TimeBeforeArbiterNonComposingAbi.find(
+  (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
+);
+const timeEqualArbiterComposingDecodeDemandFunction = TimeEqualArbiterComposingAbi.find(
+  (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
+);
+const timeEqualArbiterNonComposingDecodeDemandFunction = TimeEqualArbiterNonComposingAbi.find(
+  (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
+);
+const expirationTimeAfterArbiterComposingDecodeDemandFunction = ExpirationTimeAfterArbiterComposingAbi.find(
+  (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
+);
+const expirationTimeAfterArbiterNonComposingDecodeDemandFunction = ExpirationTimeAfterArbiterNonComposingAbi.find(
+  (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
+);
+const expirationTimeBeforeArbiterComposingDecodeDemandFunction = ExpirationTimeBeforeArbiterComposingAbi.find(
+  (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
+);
+const expirationTimeBeforeArbiterNonComposingDecodeDemandFunction = ExpirationTimeBeforeArbiterNonComposingAbi.find(
+  (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
+);
+const expirationTimeEqualArbiterComposingDecodeDemandFunction = ExpirationTimeEqualArbiterComposingAbi.find(
+  (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
+);
+const expirationTimeEqualArbiterNonComposingDecodeDemandFunction = ExpirationTimeEqualArbiterNonComposingAbi.find(
+  (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
+);
+const recipientArbiterComposingDecodeDemandFunction = RecipientArbiterComposingAbi.find(
+  (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
+);
+const recipientArbiterNonComposingDecodeDemandFunction = RecipientArbiterNonComposingAbi.find(
+  (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
+);
+const refUidArbiterComposingDecodeDemandFunction = RefUidArbiterComposingAbi.find(
+  (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
+);
+const refUidArbiterNonComposingDecodeDemandFunction = RefUidArbiterNonComposingAbi.find(
+  (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
+);
+const revocableArbiterComposingDecodeDemandFunction = RevocableArbiterComposingAbi.find(
+  (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
+);
+const revocableArbiterNonComposingDecodeDemandFunction = RevocableArbiterNonComposingAbi.find(
+  (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
+);
+const schemaArbiterComposingDecodeDemandFunction = SchemaArbiterComposingAbi.find(
+  (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
+);
+const schemaArbiterNonComposingDecodeDemandFunction = SchemaArbiterNonComposingAbi.find(
+  (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
+);
+const uidArbiterComposingDecodeDemandFunction = UidArbiterComposingAbi.find(
+  (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
+);
+const uidArbiterNonComposingDecodeDemandFunction = UidArbiterNonComposingAbi.find(
+  (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
+);
+
+// Extract the DemandData struct types from the function outputs
+const attesterArbiterComposingDemandDataType = (attesterArbiterComposingDecodeDemandFunction as { outputs: readonly any[] } | undefined)?.outputs?.[0];
+const attesterArbiterNonComposingDemandDataType = (attesterArbiterNonComposingDecodeDemandFunction as { outputs: readonly any[] } | undefined)?.outputs?.[0];
+const timeAfterArbiterComposingDemandDataType = (timeAfterArbiterComposingDecodeDemandFunction as { outputs: readonly any[] } | undefined)?.outputs?.[0];
+const timeAfterArbiterNonComposingDemandDataType = (timeAfterArbiterNonComposingDecodeDemandFunction as { outputs: readonly any[] } | undefined)?.outputs?.[0];
+const timeBeforeArbiterComposingDemandDataType = (timeBeforeArbiterComposingDecodeDemandFunction as { outputs: readonly any[] } | undefined)?.outputs?.[0];
+const timeBeforeArbiterNonComposingDemandDataType = (timeBeforeArbiterNonComposingDecodeDemandFunction as { outputs: readonly any[] } | undefined)?.outputs?.[0];
+const timeEqualArbiterComposingDemandDataType = (timeEqualArbiterComposingDecodeDemandFunction as { outputs: readonly any[] } | undefined)?.outputs?.[0];
+const timeEqualArbiterNonComposingDemandDataType = (timeEqualArbiterNonComposingDecodeDemandFunction as { outputs: readonly any[] } | undefined)?.outputs?.[0];
+const expirationTimeAfterArbiterComposingDemandDataType = (expirationTimeAfterArbiterComposingDecodeDemandFunction as { outputs: readonly any[] } | undefined)?.outputs?.[0];
+const expirationTimeAfterArbiterNonComposingDemandDataType = (expirationTimeAfterArbiterNonComposingDecodeDemandFunction as { outputs: readonly any[] } | undefined)?.outputs?.[0];
+const expirationTimeBeforeArbiterComposingDemandDataType = (expirationTimeBeforeArbiterComposingDecodeDemandFunction as { outputs: readonly any[] } | undefined)?.outputs?.[0];
+const expirationTimeBeforeArbiterNonComposingDemandDataType = (expirationTimeBeforeArbiterNonComposingDecodeDemandFunction as { outputs: readonly any[] } | undefined)?.outputs?.[0];
+const expirationTimeEqualArbiterComposingDemandDataType = (expirationTimeEqualArbiterComposingDecodeDemandFunction as { outputs: readonly any[] } | undefined)?.outputs?.[0];
+const expirationTimeEqualArbiterNonComposingDemandDataType = (expirationTimeEqualArbiterNonComposingDecodeDemandFunction as { outputs: readonly any[] } | undefined)?.outputs?.[0];
+const recipientArbiterComposingDemandDataType = (recipientArbiterComposingDecodeDemandFunction as { outputs: readonly any[] } | undefined)?.outputs?.[0];
+const recipientArbiterNonComposingDemandDataType = (recipientArbiterNonComposingDecodeDemandFunction as { outputs: readonly any[] } | undefined)?.outputs?.[0];
+const refUidArbiterComposingDemandDataType = (refUidArbiterComposingDecodeDemandFunction as { outputs: readonly any[] } | undefined)?.outputs?.[0];
+const refUidArbiterNonComposingDemandDataType = (refUidArbiterNonComposingDecodeDemandFunction as { outputs: readonly any[] } | undefined)?.outputs?.[0];
+const revocableArbiterComposingDemandDataType = (revocableArbiterComposingDecodeDemandFunction as { outputs: readonly any[] } | undefined)?.outputs?.[0];
+const revocableArbiterNonComposingDemandDataType = (revocableArbiterNonComposingDecodeDemandFunction as { outputs: readonly any[] } | undefined)?.outputs?.[0];
+const schemaArbiterComposingDemandDataType = (schemaArbiterComposingDecodeDemandFunction as { outputs: readonly any[] } | undefined)?.outputs?.[0];
+const schemaArbiterNonComposingDemandDataType = (schemaArbiterNonComposingDecodeDemandFunction as { outputs: readonly any[] } | undefined)?.outputs?.[0];
+const uidArbiterComposingDemandDataType = (uidArbiterComposingDecodeDemandFunction as { outputs: readonly any[] } | undefined)?.outputs?.[0];
+const uidArbiterNonComposingDemandDataType = (uidArbiterNonComposingDecodeDemandFunction as { outputs: readonly any[] } | undefined)?.outputs?.[0];
+
+// Ensure ABI extraction succeeded - fail fast if contract JSONs are malformed
+if (!attesterArbiterComposingDemandDataType) {
+  throw new Error('Failed to extract ABI type from AttesterArbiterComposing contract JSON. The contract definition may be missing or malformed.');
+}
+if (!attesterArbiterNonComposingDemandDataType) {
+  throw new Error('Failed to extract ABI type from AttesterArbiterNonComposing contract JSON. The contract definition may be missing or malformed.');
+}
+if (!timeAfterArbiterComposingDemandDataType) {
+  throw new Error('Failed to extract ABI type from TimeAfterArbiterComposing contract JSON. The contract definition may be missing or malformed.');
+}
+if (!timeAfterArbiterNonComposingDemandDataType) {
+  throw new Error('Failed to extract ABI type from TimeAfterArbiterNonComposing contract JSON. The contract definition may be missing or malformed.');
+}
+if (!timeBeforeArbiterComposingDemandDataType) {
+  throw new Error('Failed to extract ABI type from TimeBeforeArbiterComposing contract JSON. The contract definition may be missing or malformed.');
+}
+if (!timeBeforeArbiterNonComposingDemandDataType) {
+  throw new Error('Failed to extract ABI type from TimeBeforeArbiterNonComposing contract JSON. The contract definition may be missing or malformed.');
+}
+if (!timeEqualArbiterComposingDemandDataType) {
+  throw new Error('Failed to extract ABI type from TimeEqualArbiterComposing contract JSON. The contract definition may be missing or malformed.');
+}
+if (!timeEqualArbiterNonComposingDemandDataType) {
+  throw new Error('Failed to extract ABI type from TimeEqualArbiterNonComposing contract JSON. The contract definition may be missing or malformed.');
+}
+if (!expirationTimeAfterArbiterComposingDemandDataType) {
+  throw new Error('Failed to extract ABI type from ExpirationTimeAfterArbiterComposing contract JSON. The contract definition may be missing or malformed.');
+}
+if (!expirationTimeAfterArbiterNonComposingDemandDataType) {
+  throw new Error('Failed to extract ABI type from ExpirationTimeAfterArbiterNonComposing contract JSON. The contract definition may be missing or malformed.');
+}
+if (!expirationTimeBeforeArbiterComposingDemandDataType) {
+  throw new Error('Failed to extract ABI type from ExpirationTimeBeforeArbiterComposing contract JSON. The contract definition may be missing or malformed.');
+}
+if (!expirationTimeBeforeArbiterNonComposingDemandDataType) {
+  throw new Error('Failed to extract ABI type from ExpirationTimeBeforeArbiterNonComposing contract JSON. The contract definition may be missing or malformed.');
+}
+if (!expirationTimeEqualArbiterComposingDemandDataType) {
+  throw new Error('Failed to extract ABI type from ExpirationTimeEqualArbiterComposing contract JSON. The contract definition may be missing or malformed.');
+}
+if (!expirationTimeEqualArbiterNonComposingDemandDataType) {
+  throw new Error('Failed to extract ABI type from ExpirationTimeEqualArbiterNonComposing contract JSON. The contract definition may be missing or malformed.');
+}
+if (!recipientArbiterComposingDemandDataType) {
+  throw new Error('Failed to extract ABI type from RecipientArbiterComposing contract JSON. The contract definition may be missing or malformed.');
+}
+if (!recipientArbiterNonComposingDemandDataType) {
+  throw new Error('Failed to extract ABI type from RecipientArbiterNonComposing contract JSON. The contract definition may be missing or malformed.');
+}
+if (!refUidArbiterComposingDemandDataType) {
+  throw new Error('Failed to extract ABI type from RefUidArbiterComposing contract JSON. The contract definition may be missing or malformed.');
+}
+if (!refUidArbiterNonComposingDemandDataType) {
+  throw new Error('Failed to extract ABI type from RefUidArbiterNonComposing contract JSON. The contract definition may be missing or malformed.');
+}
+if (!revocableArbiterComposingDemandDataType) {
+  throw new Error('Failed to extract ABI type from RevocableArbiterComposing contract JSON. The contract definition may be missing or malformed.');
+}
+if (!revocableArbiterNonComposingDemandDataType) {
+  throw new Error('Failed to extract ABI type from RevocableArbiterNonComposing contract JSON. The contract definition may be missing or malformed.');
+}
+if (!schemaArbiterComposingDemandDataType) {
+  throw new Error('Failed to extract ABI type from SchemaArbiterComposing contract JSON. The contract definition may be missing or malformed.');
+}
+if (!schemaArbiterNonComposingDemandDataType) {
+  throw new Error('Failed to extract ABI type from SchemaArbiterNonComposing contract JSON. The contract definition may be missing or malformed.');
+}
+if (!uidArbiterComposingDemandDataType) {
+  throw new Error('Failed to extract ABI type from UidArbiterComposing contract JSON. The contract definition may be missing or malformed.');
+}
+if (!uidArbiterNonComposingDemandDataType) {
+  throw new Error('Failed to extract ABI type from UidArbiterNonComposing contract JSON. The contract definition may be missing or malformed.');
+}
+
 /**
  * Attestation Properties Arbiters Client
  * 
@@ -54,80 +227,6 @@ export const makeAttestationPropertiesArbitersClient = (
   viemClient: ViemClient,
   addresses: ChainAddresses,
 ) => {
-  // Extract DemandData struct ABI from contract ABIs
-  const attesterArbiterComposingDemandDataType = (AttesterArbiterComposingAbi.find(
-    (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
-  ) as { outputs: readonly any[] } | undefined)?.outputs?.[0];
-  const attesterArbiterNonComposingDemandDataType = (AttesterArbiterNonComposingAbi.find(
-    (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
-  ) as { outputs: readonly any[] } | undefined)?.outputs?.[0];
-  const timeAfterArbiterComposingDemandDataType = (TimeAfterArbiterComposingAbi.find(
-    (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
-  ) as { outputs: readonly any[] } | undefined)?.outputs?.[0];
-  const timeAfterArbiterNonComposingDemandDataType = (TimeAfterArbiterNonComposingAbi.find(
-    (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
-  ) as { outputs: readonly any[] } | undefined)?.outputs?.[0];
-  const timeBeforeArbiterComposingDemandDataType = (TimeBeforeArbiterComposingAbi.find(
-    (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
-  ) as { outputs: readonly any[] } | undefined)?.outputs?.[0];
-  const timeBeforeArbiterNonComposingDemandDataType = (TimeBeforeArbiterNonComposingAbi.find(
-    (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
-  ) as { outputs: readonly any[] } | undefined)?.outputs?.[0];
-  const timeEqualArbiterComposingDemandDataType = (TimeEqualArbiterComposingAbi.find(
-    (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
-  ) as { outputs: readonly any[] } | undefined)?.outputs?.[0];
-  const timeEqualArbiterNonComposingDemandDataType = (TimeEqualArbiterNonComposingAbi.find(
-    (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
-  ) as { outputs: readonly any[] } | undefined)?.outputs?.[0];
-  const expirationTimeAfterArbiterComposingDemandDataType = (ExpirationTimeAfterArbiterComposingAbi.find(
-    (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
-  ) as { outputs: readonly any[] } | undefined)?.outputs?.[0];
-  const expirationTimeAfterArbiterNonComposingDemandDataType = (ExpirationTimeAfterArbiterNonComposingAbi.find(
-    (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
-  ) as { outputs: readonly any[] } | undefined)?.outputs?.[0];
-  const expirationTimeBeforeArbiterComposingDemandDataType = (ExpirationTimeBeforeArbiterComposingAbi.find(
-    (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
-  ) as { outputs: readonly any[] } | undefined)?.outputs?.[0];
-  const expirationTimeBeforeArbiterNonComposingDemandDataType = (ExpirationTimeBeforeArbiterNonComposingAbi.find(
-    (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
-  ) as { outputs: readonly any[] } | undefined)?.outputs?.[0];
-  const expirationTimeEqualArbiterComposingDemandDataType = (ExpirationTimeEqualArbiterComposingAbi.find(
-    (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
-  ) as { outputs: readonly any[] } | undefined)?.outputs?.[0];
-  const expirationTimeEqualArbiterNonComposingDemandDataType = (ExpirationTimeEqualArbiterNonComposingAbi.find(
-    (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
-  ) as { outputs: readonly any[] } | undefined)?.outputs?.[0];
-  const recipientArbiterComposingDemandDataType = (RecipientArbiterComposingAbi.find(
-    (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
-  ) as { outputs: readonly any[] } | undefined)?.outputs?.[0];
-  const recipientArbiterNonComposingDemandDataType = (RecipientArbiterNonComposingAbi.find(
-    (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
-  ) as { outputs: readonly any[] } | undefined)?.outputs?.[0];
-  const refUidArbiterComposingDemandDataType = (RefUidArbiterComposingAbi.find(
-    (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
-  ) as { outputs: readonly any[] } | undefined)?.outputs?.[0];
-  const refUidArbiterNonComposingDemandDataType = (RefUidArbiterNonComposingAbi.find(
-    (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
-  ) as { outputs: readonly any[] } | undefined)?.outputs?.[0];
-  const revocableArbiterComposingDemandDataType = (RevocableArbiterComposingAbi.find(
-    (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
-  ) as { outputs: readonly any[] } | undefined)?.outputs?.[0];
-  const revocableArbiterNonComposingDemandDataType = (RevocableArbiterNonComposingAbi.find(
-    (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
-  ) as { outputs: readonly any[] } | undefined)?.outputs?.[0];
-  const schemaArbiterComposingDemandDataType = (SchemaArbiterComposingAbi.find(
-    (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
-  ) as { outputs: readonly any[] } | undefined)?.outputs?.[0];
-  const schemaArbiterNonComposingDemandDataType = (SchemaArbiterNonComposingAbi.find(
-    (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
-  ) as { outputs: readonly any[] } | undefined)?.outputs?.[0];
-  const uidArbiterComposingDemandDataType = (UidArbiterComposingAbi.find(
-    (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
-  ) as { outputs: readonly any[] } | undefined)?.outputs?.[0];
-  const uidArbiterNonComposingDemandDataType = (UidArbiterNonComposingAbi.find(
-    (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
-  ) as { outputs: readonly any[] } | undefined)?.outputs?.[0];
-
   return {
     // Attester Arbiters
     /**
@@ -139,20 +238,14 @@ export const makeAttestationPropertiesArbitersClient = (
       baseDemand: `0x${string}`;
       attester: `0x${string}`;
     }) => {
-      return encodeAbiParameters(
-        attesterArbiterComposingDemandDataType ? [attesterArbiterComposingDemandDataType] : parseAbiParameters("(address baseArbiter, bytes baseDemand, address attester)"),
-        [demand],
-      );
+      return encodeAbiParameters([attesterArbiterComposingDemandDataType], [demand]);
     },
 
     /**
      * Decodes AttesterArbiterComposing.DemandData from bytes.
      */
     decodeAttesterArbiterComposingDemand: (demandData: `0x${string}`) => {
-      return decodeAbiParameters(
-        attesterArbiterComposingDemandDataType ? [attesterArbiterComposingDemandDataType] : parseAbiParameters("(address baseArbiter, bytes baseDemand, address attester)"),
-        demandData,
-      )[0];
+      return decodeAbiParameters([attesterArbiterComposingDemandDataType], demandData)[0];
     },
 
     /**
@@ -162,20 +255,14 @@ export const makeAttestationPropertiesArbitersClient = (
     encodeAttesterArbiterNonComposingDemand: (demand: {
       attester: `0x${string}`;
     }) => {
-      return encodeAbiParameters(
-        attesterArbiterNonComposingDemandDataType ? [attesterArbiterNonComposingDemandDataType] : parseAbiParameters("(address attester)"),
-        [demand],
-      );
+      return encodeAbiParameters([attesterArbiterNonComposingDemandDataType], [demand]);
     },
 
     /**
      * Decodes AttesterArbiterNonComposing.DemandData from bytes.
      */
     decodeAttesterArbiterNonComposingDemand: (demandData: `0x${string}`) => {
-      return decodeAbiParameters(
-        attesterArbiterNonComposingDemandDataType ? [attesterArbiterNonComposingDemandDataType] : parseAbiParameters("(address attester)"),
-        demandData,
-      )[0];
+      return decodeAbiParameters([attesterArbiterNonComposingDemandDataType], demandData)[0];
     },
 
     // Time After Arbiters
@@ -189,7 +276,7 @@ export const makeAttestationPropertiesArbitersClient = (
       time: bigint;
     }) => {
       return encodeAbiParameters(
-        timeAfterArbiterComposingDemandDataType ? [timeAfterArbiterComposingDemandDataType] : parseAbiParameters("(address baseArbiter, bytes baseDemand, uint64 time)"),
+        [timeAfterArbiterComposingDemandDataType],
         [demand],
       );
     },
@@ -199,7 +286,7 @@ export const makeAttestationPropertiesArbitersClient = (
      */
     decodeTimeAfterArbiterComposingDemand: (demandData: `0x${string}`) => {
       return decodeAbiParameters(
-        timeAfterArbiterComposingDemandDataType ? [timeAfterArbiterComposingDemandDataType] : parseAbiParameters("(address baseArbiter, bytes baseDemand, uint64 time)"),
+        [timeAfterArbiterComposingDemandDataType],
         demandData,
       )[0];
     },
@@ -212,7 +299,7 @@ export const makeAttestationPropertiesArbitersClient = (
       time: bigint;
     }) => {
       return encodeAbiParameters(
-        timeAfterArbiterNonComposingDemandDataType ? [timeAfterArbiterNonComposingDemandDataType] : parseAbiParameters("(uint64 time)"),
+        [timeAfterArbiterNonComposingDemandDataType],
         [demand],
       );
     },
@@ -222,7 +309,7 @@ export const makeAttestationPropertiesArbitersClient = (
      */
     decodeTimeAfterArbiterNonComposingDemand: (demandData: `0x${string}`) => {
       return decodeAbiParameters(
-        timeAfterArbiterNonComposingDemandDataType ? [timeAfterArbiterNonComposingDemandDataType] : parseAbiParameters("(uint64 time)"),
+        [timeAfterArbiterNonComposingDemandDataType],
         demandData,
       )[0];
     },
@@ -238,7 +325,7 @@ export const makeAttestationPropertiesArbitersClient = (
       time: bigint;
     }) => {
       return encodeAbiParameters(
-        timeBeforeArbiterComposingDemandDataType ? [timeBeforeArbiterComposingDemandDataType] : parseAbiParameters("(address baseArbiter, bytes baseDemand, uint64 time)"),
+        [timeBeforeArbiterComposingDemandDataType],
         [demand],
       );
     },
@@ -248,7 +335,7 @@ export const makeAttestationPropertiesArbitersClient = (
      */
     decodeTimeBeforeArbiterComposingDemand: (demandData: `0x${string}`) => {
       return decodeAbiParameters(
-        timeBeforeArbiterComposingDemandDataType ? [timeBeforeArbiterComposingDemandDataType] : parseAbiParameters("(address baseArbiter, bytes baseDemand, uint64 time)"),
+        [timeBeforeArbiterComposingDemandDataType],
         demandData,
       )[0];
     },
@@ -261,7 +348,7 @@ export const makeAttestationPropertiesArbitersClient = (
       time: bigint;
     }) => {
       return encodeAbiParameters(
-        timeBeforeArbiterNonComposingDemandDataType ? [timeBeforeArbiterNonComposingDemandDataType] : parseAbiParameters("(uint64 time)"),
+        [timeBeforeArbiterNonComposingDemandDataType],
         [demand],
       );
     },
@@ -271,7 +358,7 @@ export const makeAttestationPropertiesArbitersClient = (
      */
     decodeTimeBeforeArbiterNonComposingDemand: (demandData: `0x${string}`) => {
       return decodeAbiParameters(
-        timeBeforeArbiterNonComposingDemandDataType ? [timeBeforeArbiterNonComposingDemandDataType] : parseAbiParameters("(uint64 time)"),
+        [timeBeforeArbiterNonComposingDemandDataType],
         demandData,
       )[0];
     },
@@ -287,7 +374,7 @@ export const makeAttestationPropertiesArbitersClient = (
       time: bigint;
     }) => {
       return encodeAbiParameters(
-        timeEqualArbiterComposingDemandDataType ? [timeEqualArbiterComposingDemandDataType] : parseAbiParameters("(address baseArbiter, bytes baseDemand, uint64 time)"),
+        [timeEqualArbiterComposingDemandDataType],
         [demand],
       );
     },
@@ -297,7 +384,7 @@ export const makeAttestationPropertiesArbitersClient = (
      */
     decodeTimeEqualArbiterComposingDemand: (demandData: `0x${string}`) => {
       return decodeAbiParameters(
-        timeEqualArbiterComposingDemandDataType ? [timeEqualArbiterComposingDemandDataType] : parseAbiParameters("(address baseArbiter, bytes baseDemand, uint64 time)"),
+        [timeEqualArbiterComposingDemandDataType],
         demandData,
       )[0];
     },
@@ -310,7 +397,7 @@ export const makeAttestationPropertiesArbitersClient = (
       time: bigint;
     }) => {
       return encodeAbiParameters(
-        timeEqualArbiterNonComposingDemandDataType ? [timeEqualArbiterNonComposingDemandDataType] : parseAbiParameters("(uint64 time)"),
+        [timeEqualArbiterNonComposingDemandDataType],
         [demand],
       );
     },
@@ -320,7 +407,7 @@ export const makeAttestationPropertiesArbitersClient = (
      */
     decodeTimeEqualArbiterNonComposingDemand: (demandData: `0x${string}`) => {
       return decodeAbiParameters(
-        timeEqualArbiterNonComposingDemandDataType ? [timeEqualArbiterNonComposingDemandDataType] : parseAbiParameters("(uint64 time)"),
+        [timeEqualArbiterNonComposingDemandDataType],
         demandData,
       )[0];
     },
@@ -336,7 +423,7 @@ export const makeAttestationPropertiesArbitersClient = (
       expirationTime: bigint;
     }) => {
       return encodeAbiParameters(
-        expirationTimeAfterArbiterComposingDemandDataType ? [expirationTimeAfterArbiterComposingDemandDataType] : parseAbiParameters("(address baseArbiter, bytes baseDemand, uint64 expirationTime)"),
+        [expirationTimeAfterArbiterComposingDemandDataType],
         [demand],
       );
     },
@@ -346,7 +433,7 @@ export const makeAttestationPropertiesArbitersClient = (
      */
     decodeExpirationTimeAfterArbiterComposingDemand: (demandData: `0x${string}`) => {
       return decodeAbiParameters(
-        expirationTimeAfterArbiterComposingDemandDataType ? [expirationTimeAfterArbiterComposingDemandDataType] : parseAbiParameters("(address baseArbiter, bytes baseDemand, uint64 expirationTime)"),
+        [expirationTimeAfterArbiterComposingDemandDataType],
         demandData,
       )[0];
     },
@@ -359,7 +446,7 @@ export const makeAttestationPropertiesArbitersClient = (
       expirationTime: bigint;
     }) => {
       return encodeAbiParameters(
-        expirationTimeAfterArbiterNonComposingDemandDataType ? [expirationTimeAfterArbiterNonComposingDemandDataType] : parseAbiParameters("(uint64 expirationTime)"),
+        [expirationTimeAfterArbiterNonComposingDemandDataType],
         [demand],
       );
     },
@@ -369,7 +456,7 @@ export const makeAttestationPropertiesArbitersClient = (
      */
     decodeExpirationTimeAfterArbiterNonComposingDemand: (demandData: `0x${string}`) => {
       return decodeAbiParameters(
-        expirationTimeAfterArbiterNonComposingDemandDataType ? [expirationTimeAfterArbiterNonComposingDemandDataType] : parseAbiParameters("(uint64 expirationTime)"),
+        [expirationTimeAfterArbiterNonComposingDemandDataType],
         demandData,
       )[0];
     },
@@ -385,7 +472,7 @@ export const makeAttestationPropertiesArbitersClient = (
       expirationTime: bigint;
     }) => {
       return encodeAbiParameters(
-        expirationTimeBeforeArbiterComposingDemandDataType ? [expirationTimeBeforeArbiterComposingDemandDataType] : parseAbiParameters("(address baseArbiter, bytes baseDemand, uint64 expirationTime)"),
+        [expirationTimeBeforeArbiterComposingDemandDataType],
         [demand],
       );
     },
@@ -395,7 +482,7 @@ export const makeAttestationPropertiesArbitersClient = (
      */
     decodeExpirationTimeBeforeArbiterComposingDemand: (demandData: `0x${string}`) => {
       return decodeAbiParameters(
-        expirationTimeBeforeArbiterComposingDemandDataType ? [expirationTimeBeforeArbiterComposingDemandDataType] : parseAbiParameters("(address baseArbiter, bytes baseDemand, uint64 expirationTime)"),
+        [expirationTimeBeforeArbiterComposingDemandDataType],
         demandData,
       )[0];
     },
@@ -408,7 +495,7 @@ export const makeAttestationPropertiesArbitersClient = (
       expirationTime: bigint;
     }) => {
       return encodeAbiParameters(
-        expirationTimeBeforeArbiterNonComposingDemandDataType ? [expirationTimeBeforeArbiterNonComposingDemandDataType] : parseAbiParameters("(uint64 expirationTime)"),
+        [expirationTimeBeforeArbiterNonComposingDemandDataType],
         [demand],
       );
     },
@@ -418,7 +505,7 @@ export const makeAttestationPropertiesArbitersClient = (
      */
     decodeExpirationTimeBeforeArbiterNonComposingDemand: (demandData: `0x${string}`) => {
       return decodeAbiParameters(
-        expirationTimeBeforeArbiterNonComposingDemandDataType ? [expirationTimeBeforeArbiterNonComposingDemandDataType] : parseAbiParameters("(uint64 expirationTime)"),
+        [expirationTimeBeforeArbiterNonComposingDemandDataType],
         demandData,
       )[0];
     },
@@ -434,7 +521,7 @@ export const makeAttestationPropertiesArbitersClient = (
       expirationTime: bigint;
     }) => {
       return encodeAbiParameters(
-        expirationTimeEqualArbiterComposingDemandDataType ? [expirationTimeEqualArbiterComposingDemandDataType] : parseAbiParameters("(address baseArbiter, bytes baseDemand, uint64 expirationTime)"),
+        [expirationTimeEqualArbiterComposingDemandDataType],
         [demand],
       );
     },
@@ -444,7 +531,7 @@ export const makeAttestationPropertiesArbitersClient = (
      */
     decodeExpirationTimeEqualArbiterComposingDemand: (demandData: `0x${string}`) => {
       return decodeAbiParameters(
-        expirationTimeEqualArbiterComposingDemandDataType ? [expirationTimeEqualArbiterComposingDemandDataType] : parseAbiParameters("(address baseArbiter, bytes baseDemand, uint64 expirationTime)"),
+        [expirationTimeEqualArbiterComposingDemandDataType],
         demandData,
       )[0];
     },
@@ -457,7 +544,7 @@ export const makeAttestationPropertiesArbitersClient = (
       expirationTime: bigint;
     }) => {
       return encodeAbiParameters(
-        expirationTimeEqualArbiterNonComposingDemandDataType ? [expirationTimeEqualArbiterNonComposingDemandDataType] : parseAbiParameters("(uint64 expirationTime)"),
+        [expirationTimeEqualArbiterNonComposingDemandDataType],
         [demand],
       );
     },
@@ -467,7 +554,7 @@ export const makeAttestationPropertiesArbitersClient = (
      */
     decodeExpirationTimeEqualArbiterNonComposingDemand: (demandData: `0x${string}`) => {
       return decodeAbiParameters(
-        expirationTimeEqualArbiterNonComposingDemandDataType ? [expirationTimeEqualArbiterNonComposingDemandDataType] : parseAbiParameters("(uint64 expirationTime)"),
+        [expirationTimeEqualArbiterNonComposingDemandDataType],
         demandData,
       )[0];
     },
@@ -483,7 +570,7 @@ export const makeAttestationPropertiesArbitersClient = (
       recipient: `0x${string}`;
     }) => {
       return encodeAbiParameters(
-        recipientArbiterComposingDemandDataType ? [recipientArbiterComposingDemandDataType] : parseAbiParameters("(address baseArbiter, bytes baseDemand, address recipient)"),
+        [recipientArbiterComposingDemandDataType],
         [demand],
       );
     },
@@ -493,7 +580,7 @@ export const makeAttestationPropertiesArbitersClient = (
      */
     decodeRecipientArbiterComposingDemand: (demandData: `0x${string}`) => {
       return decodeAbiParameters(
-        recipientArbiterComposingDemandDataType ? [recipientArbiterComposingDemandDataType] : parseAbiParameters("(address baseArbiter, bytes baseDemand, address recipient)"),
+        [recipientArbiterComposingDemandDataType],
         demandData,
       )[0];
     },
@@ -506,7 +593,7 @@ export const makeAttestationPropertiesArbitersClient = (
       recipient: `0x${string}`;
     }) => {
       return encodeAbiParameters(
-        recipientArbiterNonComposingDemandDataType ? [recipientArbiterNonComposingDemandDataType] : parseAbiParameters("(address recipient)"),
+        [recipientArbiterNonComposingDemandDataType],
         [demand],
       );
     },
@@ -516,7 +603,7 @@ export const makeAttestationPropertiesArbitersClient = (
      */
     decodeRecipientArbiterNonComposingDemand: (demandData: `0x${string}`) => {
       return decodeAbiParameters(
-        recipientArbiterNonComposingDemandDataType ? [recipientArbiterNonComposingDemandDataType] : parseAbiParameters("(address recipient)"),
+        [recipientArbiterNonComposingDemandDataType],
         demandData,
       )[0];
     },
@@ -532,7 +619,7 @@ export const makeAttestationPropertiesArbitersClient = (
       refUID: `0x${string}`;
     }) => {
       return encodeAbiParameters(
-        refUidArbiterComposingDemandDataType ? [refUidArbiterComposingDemandDataType] : parseAbiParameters("(address baseArbiter, bytes baseDemand, bytes32 refUID)"),
+        [refUidArbiterComposingDemandDataType],
         [demand],
       );
     },
@@ -542,7 +629,7 @@ export const makeAttestationPropertiesArbitersClient = (
      */
     decodeRefUidArbiterComposingDemand: (demandData: `0x${string}`) => {
       return decodeAbiParameters(
-        refUidArbiterComposingDemandDataType ? [refUidArbiterComposingDemandDataType] : parseAbiParameters("(address baseArbiter, bytes baseDemand, bytes32 refUID)"),
+        [refUidArbiterComposingDemandDataType],
         demandData,
       )[0];
     },
@@ -555,7 +642,7 @@ export const makeAttestationPropertiesArbitersClient = (
       refUID: `0x${string}`;
     }) => {
       return encodeAbiParameters(
-        refUidArbiterNonComposingDemandDataType ? [refUidArbiterNonComposingDemandDataType] : parseAbiParameters("(bytes32 refUID)"),
+        [refUidArbiterNonComposingDemandDataType],
         [demand],
       );
     },
@@ -565,7 +652,7 @@ export const makeAttestationPropertiesArbitersClient = (
      */
     decodeRefUidArbiterNonComposingDemand: (demandData: `0x${string}`) => {
       return decodeAbiParameters(
-        refUidArbiterNonComposingDemandDataType ? [refUidArbiterNonComposingDemandDataType] : parseAbiParameters("(bytes32 refUID)"),
+        [refUidArbiterNonComposingDemandDataType],
         demandData,
       )[0];
     },
@@ -581,7 +668,7 @@ export const makeAttestationPropertiesArbitersClient = (
       revocable: boolean;
     }) => {
       return encodeAbiParameters(
-        revocableArbiterComposingDemandDataType ? [revocableArbiterComposingDemandDataType] : parseAbiParameters("(address baseArbiter, bytes baseDemand, bool revocable)"),
+        [revocableArbiterComposingDemandDataType],
         [demand],
       );
     },
@@ -591,7 +678,7 @@ export const makeAttestationPropertiesArbitersClient = (
      */
     decodeRevocableArbiterComposingDemand: (demandData: `0x${string}`) => {
       return decodeAbiParameters(
-        revocableArbiterComposingDemandDataType ? [revocableArbiterComposingDemandDataType] : parseAbiParameters("(address baseArbiter, bytes baseDemand, bool revocable)"),
+        [revocableArbiterComposingDemandDataType],
         demandData,
       )[0];
     },
@@ -604,7 +691,7 @@ export const makeAttestationPropertiesArbitersClient = (
       revocable: boolean;
     }) => {
       return encodeAbiParameters(
-        revocableArbiterNonComposingDemandDataType ? [revocableArbiterNonComposingDemandDataType] : parseAbiParameters("(bool revocable)"),
+        [revocableArbiterNonComposingDemandDataType],
         [demand],
       );
     },
@@ -614,7 +701,7 @@ export const makeAttestationPropertiesArbitersClient = (
      */
     decodeRevocableArbiterNonComposingDemand: (demandData: `0x${string}`) => {
       return decodeAbiParameters(
-        revocableArbiterNonComposingDemandDataType ? [revocableArbiterNonComposingDemandDataType] : parseAbiParameters("(bool revocable)"),
+        [revocableArbiterNonComposingDemandDataType],
         demandData,
       )[0];
     },
@@ -630,7 +717,7 @@ export const makeAttestationPropertiesArbitersClient = (
       schema: `0x${string}`;
     }) => {
       return encodeAbiParameters(
-        schemaArbiterComposingDemandDataType ? [schemaArbiterComposingDemandDataType] : parseAbiParameters("(address baseArbiter, bytes baseDemand, bytes32 schema)"),
+        [schemaArbiterComposingDemandDataType],
         [demand],
       );
     },
@@ -640,7 +727,7 @@ export const makeAttestationPropertiesArbitersClient = (
      */
     decodeSchemaArbiterComposingDemand: (demandData: `0x${string}`) => {
       return decodeAbiParameters(
-        schemaArbiterComposingDemandDataType ? [schemaArbiterComposingDemandDataType] : parseAbiParameters("(address baseArbiter, bytes baseDemand, bytes32 schema)"),
+        [schemaArbiterComposingDemandDataType],
         demandData,
       )[0];
     },
@@ -653,7 +740,7 @@ export const makeAttestationPropertiesArbitersClient = (
       schema: `0x${string}`;
     }) => {
       return encodeAbiParameters(
-        schemaArbiterNonComposingDemandDataType ? [schemaArbiterNonComposingDemandDataType] : parseAbiParameters("(bytes32 schema)"),
+        [schemaArbiterNonComposingDemandDataType],
         [demand],
       );
     },
@@ -663,7 +750,7 @@ export const makeAttestationPropertiesArbitersClient = (
      */
     decodeSchemaArbiterNonComposingDemand: (demandData: `0x${string}`) => {
       return decodeAbiParameters(
-        schemaArbiterNonComposingDemandDataType ? [schemaArbiterNonComposingDemandDataType] : parseAbiParameters("(bytes32 schema)"),
+        [schemaArbiterNonComposingDemandDataType],
         demandData,
       )[0];
     },
@@ -679,7 +766,7 @@ export const makeAttestationPropertiesArbitersClient = (
       uid: `0x${string}`;
     }) => {
       return encodeAbiParameters(
-        uidArbiterComposingDemandDataType ? [uidArbiterComposingDemandDataType] : parseAbiParameters("(address baseArbiter, bytes baseDemand, bytes32 uid)"),
+        [uidArbiterComposingDemandDataType],
         [demand],
       );
     },
@@ -689,7 +776,7 @@ export const makeAttestationPropertiesArbitersClient = (
      */
     decodeUidArbiterComposingDemand: (demandData: `0x${string}`) => {
       return decodeAbiParameters(
-        uidArbiterComposingDemandDataType ? [uidArbiterComposingDemandDataType] : parseAbiParameters("(address baseArbiter, bytes baseDemand, bytes32 uid)"),
+        [uidArbiterComposingDemandDataType],
         demandData,
       )[0];
     },
@@ -702,7 +789,7 @@ export const makeAttestationPropertiesArbitersClient = (
       uid: `0x${string}`;
     }) => {
       return encodeAbiParameters(
-        uidArbiterNonComposingDemandDataType ? [uidArbiterNonComposingDemandDataType] : parseAbiParameters("(bytes32 uid)"),
+        [uidArbiterNonComposingDemandDataType],
         [demand],
       );
     },
@@ -712,7 +799,7 @@ export const makeAttestationPropertiesArbitersClient = (
      */
     decodeUidArbiterNonComposingDemand: (demandData: `0x${string}`) => {
       return decodeAbiParameters(
-        uidArbiterNonComposingDemandDataType ? [uidArbiterNonComposingDemandDataType] : parseAbiParameters("(bytes32 uid)"),
+        [uidArbiterNonComposingDemandDataType],
         demandData,
       )[0];
     },

--- a/src/clients/erc1155.ts
+++ b/src/clients/erc1155.ts
@@ -27,6 +27,15 @@ export const makeErc1155Client = (
   viemClient: ViemClient,
   addresses: ChainAddresses,
 ) => {
+  // Extract ABI types for encoding/decoding from contract ABIs
+  const escrowObligationDataType = erc1155EscrowAbi.abi.find(
+    (item) => item.type === "function" && item.name === "decodeObligationData"
+  )?.outputs?.[0];
+
+  const paymentObligationDataType = erc1155PaymentAbi.abi.find(
+    (item) => item.type === "function" && item.name === "decodeObligationData"
+  )?.outputs?.[0];
+
   /**
    * Encodes ERC1155EscrowObligation.ObligationData to bytes using raw parameters.
    * @param data - ObligationData object to encode
@@ -40,7 +49,7 @@ export const makeErc1155Client = (
     amount: bigint;
   }) => {
     return encodeAbiParameters(
-      parseAbiParameters(
+      escrowObligationDataType ? [escrowObligationDataType] : parseAbiParameters(
         "(address arbiter, bytes demand, address token, uint256 tokenId, uint256 amount)",
       ),
       [data],
@@ -59,7 +68,7 @@ export const makeErc1155Client = (
     payee: `0x${string}`;
   }) => {
     return encodeAbiParameters(
-      parseAbiParameters(
+      paymentObligationDataType ? [paymentObligationDataType] : parseAbiParameters(
         "(address token, uint256 tokenId, uint256 amount, address payee)",
       ),
       [data],
@@ -107,7 +116,7 @@ export const makeErc1155Client = (
      */
     decodeEscrowObligation: (obligationData: `0x${string}`) => {
       return decodeAbiParameters(
-        parseAbiParameters(
+        escrowObligationDataType ? [escrowObligationDataType] : parseAbiParameters(
           "(address arbiter, bytes demand, address token, uint256 tokenId, uint256 amount)",
         ),
         obligationData,
@@ -120,7 +129,7 @@ export const makeErc1155Client = (
      */
     decodePaymentObligation: (obligationData: `0x${string}`) => {
       return decodeAbiParameters(
-        parseAbiParameters(
+        paymentObligationDataType ? [paymentObligationDataType] : parseAbiParameters(
           "(address token, uint256 tokenId, uint256 amount, address payee)",
         ),
         obligationData,

--- a/src/clients/erc721.ts
+++ b/src/clients/erc721.ts
@@ -27,6 +27,15 @@ export const makeErc721Client = (
   viemClient: ViemClient,
   addresses: ChainAddresses,
 ) => {
+  // Extract ABI types for encoding/decoding from contract ABIs
+  const escrowObligationDataType = erc721EscrowAbi.abi.find(
+    (item) => item.type === "function" && item.name === "decodeObligationData"
+  )?.outputs?.[0];
+
+  const paymentObligationDataType = erc721PaymentAbi.abi.find(
+    (item) => item.type === "function" && item.name === "decodeObligationData"
+  )?.outputs?.[0];
+
   /**
    * Encodes ERC721EscrowObligation.ObligationData to bytes using raw parameters.
    * @param data - ObligationData object to encode
@@ -39,7 +48,7 @@ export const makeErc721Client = (
     tokenId: bigint;
   }) => {
     return encodeAbiParameters(
-      parseAbiParameters(
+      escrowObligationDataType ? [escrowObligationDataType] : parseAbiParameters(
         "(address arbiter, bytes demand, address token, uint256 tokenId)",
       ),
       [data],
@@ -57,7 +66,7 @@ export const makeErc721Client = (
     payee: `0x${string}`;
   }) => {
     return encodeAbiParameters(
-      parseAbiParameters("(address token, uint256 tokenId, address payee)"),
+      paymentObligationDataType ? [paymentObligationDataType] : parseAbiParameters("(address token, uint256 tokenId, address payee)"),
       [data],
     );
   };
@@ -101,7 +110,7 @@ export const makeErc721Client = (
      */
     decodeEscrowObligation: (obligationData: `0x${string}`) => {
       return decodeAbiParameters(
-        parseAbiParameters(
+        escrowObligationDataType ? [escrowObligationDataType] : parseAbiParameters(
           "(address token, uint256 tokenId, address arbiter, bytes demand)",
         ),
         obligationData,
@@ -114,7 +123,7 @@ export const makeErc721Client = (
      */
     decodePaymentObligation: (obligationData: `0x${string}`) => {
       return decodeAbiParameters(
-        parseAbiParameters("(address token, uint256 tokenId, address payee)"),
+        paymentObligationDataType ? [paymentObligationDataType] : parseAbiParameters("(address token, uint256 tokenId, address payee)"),
         obligationData,
       )[0];
     },

--- a/src/clients/generalArbiters.ts
+++ b/src/clients/generalArbiters.ts
@@ -12,6 +12,43 @@ import { abi as IntrinsicsArbiter2Abi } from "../contracts/IntrinsicsArbiter2";
 import { abi as TrustedPartyArbiterAbi } from "../contracts/TrustedPartyArbiter";
 import { abi as SpecificAttestationArbiterAbi } from "../contracts/SpecificAttestationArbiter";
 
+// Extract DemandData struct ABI from contract ABIs at module initialization
+const intrinsicsArbiter2DecodeDemandFunction = IntrinsicsArbiter2Abi.abi.find(
+  (item) => item.type === 'function' && item.name === 'decodeDemandData'
+);
+const trustedPartyArbiterDecodeDemandFunction = TrustedPartyArbiterAbi.abi.find(
+  (item) => item.type === 'function' && item.name === 'decodeDemandData'
+);
+const specificAttestationArbiterDecodeDemandFunction = SpecificAttestationArbiterAbi.abi.find(
+  (item) => item.type === 'function' && item.name === 'decodeDemandData'
+);
+const trustedOracleArbiterDecodeDemandFunction = trustedOracleArbiterAbi.abi.find(
+  (item) => item.type === 'function' && item.name === 'decodeDemandData'
+);
+
+// Extract the DemandData struct types from the function outputs
+const intrinsicsArbiter2DemandDataType = intrinsicsArbiter2DecodeDemandFunction?.outputs?.[0];
+const trustedPartyArbiterDemandDataType = trustedPartyArbiterDecodeDemandFunction?.outputs?.[0];
+const specificAttestationArbiterDemandDataType = specificAttestationArbiterDecodeDemandFunction?.outputs?.[0];
+const trustedOracleArbiterDemandDataType = trustedOracleArbiterDecodeDemandFunction?.outputs?.[0];
+
+// Ensure ABI extraction succeeded - fail fast if contract JSONs are malformed
+if (!intrinsicsArbiter2DemandDataType) {
+  throw new Error('Failed to extract ABI type from IntrinsicsArbiter2 contract JSON. The contract definition may be missing or malformed.');
+}
+
+if (!trustedPartyArbiterDemandDataType) {
+  throw new Error('Failed to extract ABI type from TrustedPartyArbiter contract JSON. The contract definition may be missing or malformed.');
+}
+
+if (!specificAttestationArbiterDemandDataType) {
+  throw new Error('Failed to extract ABI type from SpecificAttestationArbiter contract JSON. The contract definition may be missing or malformed.');
+}
+
+if (!trustedOracleArbiterDemandDataType) {
+  throw new Error('Failed to extract ABI type from TrustedOracleArbiter contract JSON. The contract definition may be missing or malformed.');
+}
+
 /**
  * General Arbiters Client
  * 
@@ -27,25 +64,6 @@ export const makeGeneralArbitersClient = (
   viemClient: ViemClient,
   addresses: ChainAddresses,
 ) => {
-  // Extract DemandData struct ABI from contract ABIs
-  const intrinsicsArbiter2DecodeDemandFunction = IntrinsicsArbiter2Abi.abi.find(
-    (item) => item.type === 'function' && item.name === 'decodeDemandData'
-  );
-  const trustedPartyArbiterDecodeDemandFunction = TrustedPartyArbiterAbi.abi.find(
-    (item) => item.type === 'function' && item.name === 'decodeDemandData'
-  );
-  const specificAttestationArbiterDecodeDemandFunction = SpecificAttestationArbiterAbi.abi.find(
-    (item) => item.type === 'function' && item.name === 'decodeDemandData'
-  );
-  const trustedOracleArbiterDecodeDemandFunction = trustedOracleArbiterAbi.abi.find(
-    (item) => item.type === 'function' && item.name === 'decodeDemandData'
-  );
-
-  // Extract the DemandData struct types from the function outputs
-  const intrinsicsArbiter2DemandDataType = intrinsicsArbiter2DecodeDemandFunction?.outputs?.[0];
-  const trustedPartyArbiterDemandDataType = trustedPartyArbiterDecodeDemandFunction?.outputs?.[0];
-  const specificAttestationArbiterDemandDataType = specificAttestationArbiterDecodeDemandFunction?.outputs?.[0];
-  const trustedOracleArbiterDemandDataType = trustedOracleArbiterDecodeDemandFunction?.outputs?.[0];
 
   // Cache the parsed event ABIs to avoid re-parsing on each call
   const arbitrationMadeEvent = parseAbiItem(
@@ -63,9 +81,6 @@ export const makeGeneralArbitersClient = (
      * @returns abi encoded bytes
      */
     encodeIntrinsics2Demand: (demand: { schema: `0x${string}` }) => {
-      if (!intrinsicsArbiter2DemandDataType) {
-        throw new Error("IntrinsicsArbiter2 DemandData ABI not found");
-      }
       return encodeAbiParameters([intrinsicsArbiter2DemandDataType], [demand]);
     },
 
@@ -75,9 +90,6 @@ export const makeGeneralArbitersClient = (
      * @returns the decoded DemandData object
      */
     decodeIntrinsics2Demand: (demandData: `0x${string}`) => {
-      if (!intrinsicsArbiter2DemandDataType) {
-        throw new Error("IntrinsicsArbiter2 DemandData ABI not found");
-      }
       return decodeAbiParameters([intrinsicsArbiter2DemandDataType], demandData)[0];
     },
 
@@ -91,9 +103,6 @@ export const makeGeneralArbitersClient = (
       baseDemand: `0x${string}`;
       creator: `0x${string}`;
     }) => {
-      if (!trustedPartyArbiterDemandDataType) {
-        throw new Error("TrustedPartyArbiter DemandData ABI not found");
-      }
       return encodeAbiParameters([trustedPartyArbiterDemandDataType], [demand]);
     },
 
@@ -103,9 +112,6 @@ export const makeGeneralArbitersClient = (
      * @returns the decoded DemandData object
      */
     decodeTrustedPartyDemand: (demandData: `0x${string}`) => {
-      if (!trustedPartyArbiterDemandDataType) {
-        throw new Error("TrustedPartyArbiter DemandData ABI not found");
-      }
       return decodeAbiParameters([trustedPartyArbiterDemandDataType], demandData)[0];
     },
 
@@ -115,9 +121,6 @@ export const makeGeneralArbitersClient = (
      * @returns abi encoded bytes
      */
     encodeSpecificAttestationDemand: (demand: { uid: `0x${string}` }) => {
-      if (!specificAttestationArbiterDemandDataType) {
-        throw new Error("SpecificAttestationArbiter DemandData ABI not found");
-      }
       return encodeAbiParameters([specificAttestationArbiterDemandDataType], [demand]);
     },
 
@@ -127,9 +130,6 @@ export const makeGeneralArbitersClient = (
      * @returns the decoded DemandData object
      */
     decodeSpecificAttestationDemand: (demandData: `0x${string}`) => {
-      if (!specificAttestationArbiterDemandDataType) {
-        throw new Error("SpecificAttestationArbiter DemandData ABI not found");
-      }
       return decodeAbiParameters([specificAttestationArbiterDemandDataType], demandData)[0];
     },
 
@@ -142,9 +142,6 @@ export const makeGeneralArbitersClient = (
       oracle: `0x${string}`;
       data: `0x${string}`;
     }) => {
-      if (!trustedOracleArbiterDemandDataType) {
-        throw new Error("TrustedOracleArbiter DemandData ABI not found");
-      }
       return encodeAbiParameters([trustedOracleArbiterDemandDataType], [demand]);
     },
 
@@ -154,9 +151,6 @@ export const makeGeneralArbitersClient = (
      * @returns the decoded DemandData object
      */
     decodeTrustedOracleDemand: (demandData: `0x${string}`) => {
-      if (!trustedOracleArbiterDemandDataType) {
-        throw new Error("TrustedOracleArbiter DemandData ABI not found");
-      }
       return decodeAbiParameters([trustedOracleArbiterDemandDataType], demandData)[0];
     },
 

--- a/src/clients/generalArbiters.ts
+++ b/src/clients/generalArbiters.ts
@@ -18,14 +18,20 @@ import { abi as trustedOracleArbiterAbi } from "../contracts/TrustedOracleArbite
  * - TrustedPartyArbiter: Creator-based validation with composable base arbiter
  * - SpecificAttestationArbiter: Validates against a specific attestation UID
  * - TrustedOracleArbiter: Oracle-based decision making with arbitration requests
+ *   - Supports requestArbitration for requesting arbitration from specific oracles
+ *   - Provides listening functions for oracles to respond only to arbitration requests
  */
 export const makeGeneralArbitersClient = (
   viemClient: ViemClient,
   addresses: ChainAddresses,
 ) => {
-  // Cache the parsed event ABI to avoid re-parsing on each call
+  // Cache the parsed event ABIs to avoid re-parsing on each call
   const arbitrationMadeEvent = parseAbiItem(
-    "event ArbitrationMade(bytes32 indexed statement, address indexed oracle, bool decision)",
+    "event ArbitrationMade(bytes32 indexed obligation, address indexed oracle, bool decision)",
+  );
+  
+  const arbitrationRequestedEvent = parseAbiItem(
+    "event ArbitrationRequested(bytes32 indexed obligation, address indexed oracle)",
   );
 
   return {
@@ -135,48 +141,67 @@ export const makeGeneralArbitersClient = (
     /**
      * Arbitrate on the validality of an obligation fulfilling
      * a demand for TrustedOracleArbiter
-     * @param statement - bytes32 statement
+     * @param obligation - bytes32 obligation
      * @param decision - bool decision
      * @returns transaction hash
      */
     arbitrateAsTrustedOracle: async (
-      statement: `0x${string}`,
+      obligation: `0x${string}`,
       decision: boolean,
     ) => {
       const hash = await viemClient.writeContract({
         address: addresses.trustedOracleArbiter,
         abi: trustedOracleArbiterAbi.abi,
         functionName: "arbitrate",
-        args: [statement, decision],
+        args: [obligation, decision],
       });
       return hash;
     },
 
     /**
-     * Check if an arbitration has already been made for a specific statement by a specific oracle
-     * @param statement - bytes32 statement uid
+     * Request arbitration on an obligation from TrustedOracleArbiter
+     * @param obligation - bytes32 obligation uid
+     * @param oracle - address of the oracle to request arbitration from
+     * @returns transaction hash
+     */
+    requestArbitrationFromTrustedOracle: async (
+      obligation: `0x${string}`,
+      oracle: `0x${string}`,
+    ) => {
+      const hash = await viemClient.writeContract({
+        address: addresses.trustedOracleArbiter,
+        abi: trustedOracleArbiterAbi.abi,
+        functionName: "requestArbitration",
+        args: [obligation, oracle],
+      });
+      return hash;
+    },
+
+    /**
+     * Check if an arbitration has already been made for a specific obligation by a specific oracle
+     * @param obligation - bytes32 obligation uid
      * @param oracle - address of the oracle
      * @returns the arbitration result if exists, undefined if not
      */
     checkExistingArbitration: async (
-      statement: `0x${string}`,
+      obligation: `0x${string}`,
       oracle: `0x${string}`,
     ): Promise<{
-      statement: `0x${string}`;
+      obligation: `0x${string}`;
       oracle: `0x${string}`;
       decision: boolean;
     } | undefined> => {
       const logs = await viemClient.getLogs({
         address: addresses.trustedOracleArbiter,
         event: arbitrationMadeEvent,
-        args: { statement, oracle },
+        args: { obligation, oracle },
         fromBlock: "earliest",
         toBlock: "latest",
       });
 
       if (logs.length > 0) {
         return logs[0].args as {
-          statement: `0x${string}`;
+          obligation: `0x${string}`;
           oracle: `0x${string}`;
           decision: boolean;
         };
@@ -187,24 +212,24 @@ export const makeGeneralArbitersClient = (
 
     /**
      * Wait for an arbitration to be made on a TrustedOracleArbiter
-     * @param statement - bytes32 statement uid
+     * @param obligation - bytes32 obligation uid
      * @param oracle - address of the oracle
      * @param pollingInterval - polling interval in milliseconds (default: 1000)
      * @returns the event args
      */
     waitForTrustedOracleArbitration: async (
-      statement: `0x${string}`,
+      obligation: `0x${string}`,
       oracle: `0x${string}`,
       pollingInterval?: number,
     ): Promise<{
-      statement?: `0x${string}` | undefined;
+      obligation?: `0x${string}` | undefined;
       oracle?: `0x${string}` | undefined;
       decision?: boolean | undefined;
     }> => {
       const logs = await viemClient.getLogs({
         address: addresses.trustedOracleArbiter,
         event: arbitrationMadeEvent,
-        args: { statement, oracle },
+        args: { obligation, oracle },
         fromBlock: "earliest",
         toBlock: "latest",
       });
@@ -218,7 +243,7 @@ export const makeGeneralArbitersClient = (
         const unwatch = viemClient.watchEvent({
           address: addresses.trustedOracleArbiter,
           event: arbitrationMadeEvent,
-          args: { statement, oracle },
+          args: { obligation, oracle },
           pollingInterval: optimalInterval,
           onLogs: (logs) => {
             resolve(logs[0].args);
@@ -226,6 +251,96 @@ export const makeGeneralArbitersClient = (
           },
           fromBlock: 1n,
         });
+      });
+    },
+
+    /**
+     * Wait for an arbitration request to be made on a TrustedOracleArbiter
+     * @param obligation - bytes32 obligation uid  
+     * @param oracle - address of the oracle
+     * @param pollingInterval - polling interval in milliseconds (default: 1000)
+     * @returns the event args
+     */
+    waitForTrustedOracleArbitrationRequest: async (
+      obligation: `0x${string}`,
+      oracle: `0x${string}`,
+      pollingInterval?: number,
+    ): Promise<{
+      obligation?: `0x${string}` | undefined;
+      oracle?: `0x${string}` | undefined;
+    }> => {
+      const logs = await viemClient.getLogs({
+        address: addresses.trustedOracleArbiter,
+        event: arbitrationRequestedEvent,
+        args: { obligation, oracle },
+        fromBlock: "earliest",
+        toBlock: "latest",
+      });
+
+      if (logs.length) return logs[0].args;
+
+      // Use optimal polling interval based on transport type
+      const optimalInterval = getOptimalPollingInterval(viemClient, pollingInterval ?? 1000);
+
+      return new Promise((resolve) => {
+        const unwatch = viemClient.watchEvent({
+          address: addresses.trustedOracleArbiter,
+          event: arbitrationRequestedEvent,
+          args: { obligation, oracle },
+          pollingInterval: optimalInterval,
+          onLogs: (logs) => {
+            resolve(logs[0].args);
+            unwatch();
+          },
+          fromBlock: 1n,
+        });
+      });
+    },
+
+    /**
+     * Listen for arbitration requests and only arbitrate on request
+     * This function continuously listens for ArbitrationRequested events
+     * and calls the provided arbitration handler for each request
+     * @param oracle - address of the oracle (filter for requests to this oracle)
+     * @param arbitrationHandler - function to handle arbitration requests
+     * @param pollingInterval - polling interval in milliseconds (default: 1000)
+     * @returns unwatch function to stop listening
+     */
+    listenForArbitrationRequestsOnly: (
+      oracle: `0x${string}`,
+      arbitrationHandler: (obligation: `0x${string}`, oracle: `0x${string}`) => Promise<boolean>,
+      pollingInterval?: number,
+    ) => {
+      // Use optimal polling interval based on transport type
+      const optimalInterval = getOptimalPollingInterval(viemClient, pollingInterval ?? 1000);
+
+      return viemClient.watchEvent({
+        address: addresses.trustedOracleArbiter,
+        event: arbitrationRequestedEvent,
+        args: { oracle },
+        pollingInterval: optimalInterval,
+        onLogs: async (logs) => {
+          for (const log of logs) {
+            const { obligation: requestedObligation, oracle: requestedOracle } = log.args;
+            if (requestedObligation && requestedOracle) {
+              try {
+                // Call the arbitration handler to get the decision
+                const decision = await arbitrationHandler(requestedObligation, requestedOracle);
+                
+                // Submit the arbitration
+                await viemClient.writeContract({
+                  address: addresses.trustedOracleArbiter,
+                  abi: trustedOracleArbiterAbi.abi,
+                  functionName: "arbitrate",
+                  args: [requestedObligation, decision],
+                });
+              } catch (error) {
+                console.error(`Failed to arbitrate for obligation ${requestedObligation}:`, error);
+              }
+            }
+          }
+        },
+        fromBlock: 1n,
       });
     },
   };

--- a/src/clients/logicalArbiters.ts
+++ b/src/clients/logicalArbiters.ts
@@ -1,10 +1,11 @@
 import {
   decodeAbiParameters,
   encodeAbiParameters,
-  parseAbiParameters,
 } from "viem";
 import type { ViemClient } from "../utils";
 import type { ChainAddresses } from "../types";
+import { abi as AllArbiterAbi } from "../contracts/AllArbiter";
+import { abi as AnyArbiterAbi } from "../contracts/AnyArbiter";
 
 /**
  * Logical Arbiters Client
@@ -20,6 +21,18 @@ export const makeLogicalArbitersClient = (
   viemClient: ViemClient,
   addresses: ChainAddresses,
 ) => {
+  // Extract DemandData struct ABI from contract ABIs
+  const anyArbiterDecodeDemandFunction = AnyArbiterAbi.abi.find(
+    (item) => item.type === 'function' && item.name === 'decodeDemandData'
+  );
+  const allArbiterDecodeDemandFunction = AllArbiterAbi.abi.find(
+    (item) => item.type === 'function' && item.name === 'decodeDemandData'
+  );
+
+  // Extract the DemandData struct type from the function outputs
+  const anyDemandDataType = anyArbiterDecodeDemandFunction?.outputs?.[0];
+  const allDemandDataType = allArbiterDecodeDemandFunction?.outputs?.[0];
+
   return {
     /**
      * Encodes AnyArbiter.DemandData to bytes.
@@ -30,10 +43,10 @@ export const makeLogicalArbitersClient = (
       arbiters: `0x${string}`[];
       demands: `0x${string}`[];
     }) => {
-      return encodeAbiParameters(
-        parseAbiParameters("(address[] arbiters, bytes[] demands)"),
-        [demand],
-      );
+      if (!anyDemandDataType) {
+        throw new Error("AnyArbiter DemandData ABI not found");
+      }
+      return encodeAbiParameters([anyDemandDataType], [demand]);
     },
 
     /**
@@ -42,10 +55,10 @@ export const makeLogicalArbitersClient = (
      * @returns the decoded DemandData object
      */
     decodeAnyArbiterDemand: (demandData: `0x${string}`) => {
-      return decodeAbiParameters(
-        parseAbiParameters("(address[] arbiters, bytes[] demands)"),
-        demandData,
-      )[0];
+      if (!anyDemandDataType) {
+        throw new Error("AnyArbiter DemandData ABI not found");
+      }
+      return decodeAbiParameters([anyDemandDataType], demandData)[0];
     },
 
     /**
@@ -57,10 +70,10 @@ export const makeLogicalArbitersClient = (
       arbiters: `0x${string}`[];
       demands: `0x${string}`[];
     }) => {
-      return encodeAbiParameters(
-        parseAbiParameters("(address[] arbiters, bytes[] demands)"),
-        [demand],
-      );
+      if (!allDemandDataType) {
+        throw new Error("AllArbiter DemandData ABI not found");
+      }
+      return encodeAbiParameters([allDemandDataType], [demand]);
     },
 
     /**
@@ -69,10 +82,10 @@ export const makeLogicalArbitersClient = (
      * @returns the decoded DemandData object
      */
     decodeAllArbiterDemand: (demandData: `0x${string}`) => {
-      return decodeAbiParameters(
-        parseAbiParameters("(address[] arbiters, bytes[] demands)"),
-        demandData,
-      )[0];
+      if (!allDemandDataType) {
+        throw new Error("AllArbiter DemandData ABI not found");
+      }
+      return decodeAbiParameters([allDemandDataType], demandData)[0];
     },
   };
 };

--- a/src/clients/stringObligation.ts
+++ b/src/clients/stringObligation.ts
@@ -28,9 +28,14 @@ export const makeStringObligationClient = (
   viemClient: ViemClient,
   addresses: ChainAddresses,
 ) => {
+  // Extract ABI type for encoding/decoding from contract ABI
+  const obligationDataType = stringObligationAbi.abi.find(
+    (item) => item.type === "function" && item.name === "decodeObligationData"
+  )?.outputs?.[0];
+
   const decode = (obligationData: `0x${string}`) => {
     return decodeAbiParameters(
-      parseAbiParameters("(string item)"),
+      obligationDataType ? [obligationDataType] : parseAbiParameters("(string item)"),
       obligationData,
     )[0];
   };
@@ -65,7 +70,10 @@ export const makeStringObligationClient = (
 
   return {
     encode: (data: { item: string }) => {
-      return encodeAbiParameters(parseAbiParameters("(string item)"), [data]);
+      return encodeAbiParameters(
+        obligationDataType ? [obligationDataType] : parseAbiParameters("(string item)"), 
+        [data]
+      );
     },
     decode,
     decodeJson: <T>(obligationData: `0x${string}`) => {
@@ -121,7 +129,7 @@ export const makeStringObligationClient = (
         throw new Error(`Unsupported schema: ${attestation.schema}`);
       }
       const data = decodeAbiParameters(
-        parseAbiParameters("(string item)"),
+        obligationDataType ? [obligationDataType] : parseAbiParameters("(string item)"),
         attestation.data,
       )[0];
 
@@ -140,7 +148,7 @@ export const makeStringObligationClient = (
         throw new Error(`Unsupported schema: ${attestation.schema}`);
       }
       const data = decodeAbiParameters(
-        parseAbiParameters("(string item)"),
+        obligationDataType ? [obligationDataType] : parseAbiParameters("(string item)"),
         attestation.data,
       )[0];
 

--- a/src/clients/tokenBundle.ts
+++ b/src/clients/tokenBundle.ts
@@ -22,6 +22,15 @@ export const makeTokenBundleClient = (
   viemClient: ViemClient,
   addresses: ChainAddresses,
 ) => {
+  // Extract ABI types for encoding/decoding from contract ABIs
+  const escrowObligationDataType = tokenBundleEscrowAbi.abi.find(
+    (item) => item.type === "function" && item.name === "decodeObligationData"
+  )?.outputs?.[0];
+
+  const paymentObligationDataType = tokenBundlePaymentAbi.abi.find(
+    (item) => item.type === "function" && item.name === "decodeObligationData"
+  )?.outputs?.[0];
+
   /**
    * Encodes TokenBundleEscrowObligation.ObligationData to bytes using raw parameters.
    * @param data - ObligationData object to encode
@@ -39,7 +48,7 @@ export const makeTokenBundleClient = (
     demand: `0x${string}`;
   }) => {
     return encodeAbiParameters(
-      parseAbiParameters(
+      escrowObligationDataType ? [escrowObligationDataType] : parseAbiParameters(
         "(address arbiter, bytes demand, address[] erc20Tokens, uint256[] erc20Amounts, address[] erc721Tokens, uint256[] erc721TokenIds, address[] erc1155Tokens, uint256[] erc1155TokenIds, uint256[] erc1155Amounts)",
       ),
       [data],
@@ -62,7 +71,7 @@ export const makeTokenBundleClient = (
     payee: `0x${string}`;
   }) => {
     return encodeAbiParameters(
-      parseAbiParameters(
+      paymentObligationDataType ? [paymentObligationDataType] : parseAbiParameters(
         "(address[] erc20Tokens, uint256[] erc20Amounts, address[] erc721Tokens, uint256[] erc721TokenIds, address[] erc1155Tokens, uint256[] erc1155TokenIds, uint256[] erc1155Amounts, address payee)",
       ),
       [data],
@@ -110,7 +119,7 @@ export const makeTokenBundleClient = (
      */
     decodeEscrowObligation: (obligationData: `0x${string}`) => {
       return decodeAbiParameters(
-        parseAbiParameters(
+        escrowObligationDataType ? [escrowObligationDataType] : parseAbiParameters(
           "(address[] erc20Tokens, uint256[] erc20Amounts, address[] erc721Tokens, uint256[] erc721TokenIds, address[] erc1155Tokens, uint256[] erc1155TokenIds, uint256[] erc1155Amounts)",
         ),
         obligationData,
@@ -123,7 +132,7 @@ export const makeTokenBundleClient = (
      */
     decodePaymentObligation: (obligationData: `0x${string}`) => {
       return decodeAbiParameters(
-        parseAbiParameters(
+        paymentObligationDataType ? [paymentObligationDataType] : parseAbiParameters(
           "(address[] erc20Tokens, uint256[] erc20Amounts, address[] erc721Tokens, uint256[] erc721TokenIds, address[] erc1155Tokens, uint256[] erc1155TokenIds, uint256[] erc1155Amounts, address payee)",
         ),
         obligationData,


### PR DESCRIPTION
## What I Did:
- Add support for requestArbitration and tests in generalArbiter
- CHANGE: Use ABI Object from json
- simple test in logicalArbiter to check the the Encode/Decode refactoring work well.