### PR TITLE
Using @viem `getAbiItem()` to get contract's functions.

### DIFF
--- a/src/clients/attestation.ts
+++ b/src/clients/attestation.ts
@@ -10,6 +10,7 @@ import { abi as attestationBarterUtilsAbi } from "../contracts/AttestationBarter
 import {
   decodeAbiParameters,
   encodeAbiParameters,
+  getAbiItem,
 } from "viem";
 
 export const makeAttestationClient = (
@@ -17,22 +18,15 @@ export const makeAttestationClient = (
   addresses: ChainAddresses,
 ) => {
   // Extract ABI types for encoding/decoding from contract ABIs
-  const escrowObligationDataType = attestationEscrowAbi.abi.find(
-    (item) => item.type === "function" && item.name === "decodeObligationData"
-  )?.outputs?.[0];
+  const escrowObligationDataType = getAbiItem({
+    abi: attestationEscrowAbi.abi,
+    name: "decodeObligationData"
+  }).outputs[0];
 
-  const escrow2ObligationDataType = attestationEscrow2Abi.abi.find(
-    (item) => item.type === "function" && item.name === "decodeObligationData"
-  )?.outputs?.[0];
-
-  // Ensure ABI extraction succeeded - fail fast if contract JSONs are malformed
-  if (!escrowObligationDataType) {
-    throw new Error('Failed to extract ABI type from AttestationEscrowObligation contract JSON. The contract definition may be missing or malformed.');
-  }
-
-  if (!escrow2ObligationDataType) {
-    throw new Error('Failed to extract ABI type from AttestationEscrowObligation2 contract JSON. The contract definition may be missing or malformed.');
-  }
+  const escrow2ObligationDataType = getAbiItem({
+    abi: attestationEscrow2Abi.abi,
+    name: "decodeObligationData"
+  }).outputs[0];
 
   // Use contract ABIs directly
   const attestationAbi = [escrowObligationDataType];

--- a/src/clients/attestationPropertiesArbiters.ts
+++ b/src/clients/attestationPropertiesArbiters.ts
@@ -1,6 +1,7 @@
 import {
   decodeAbiParameters,
   encodeAbiParameters,
+  getAbiItem,
 } from "viem";
 import type { ViemClient } from "../utils";
 import type { ChainAddresses } from "../types";
@@ -32,104 +33,132 @@ import { abi as UidArbiterComposingAbi } from "../contracts/UidArbiterComposing"
 import { abi as UidArbiterNonComposingAbi } from "../contracts/UidArbiterNonComposing";
 
 // Extract DemandData struct ABIs from contract ABIs at module initialization
-const attesterArbiterComposingDecodeDemandFunction = AttesterArbiterComposingAbi.find(
-  (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
-);
-const attesterArbiterNonComposingDecodeDemandFunction = AttesterArbiterNonComposingAbi.find(
-  (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
-);
-const timeAfterArbiterComposingDecodeDemandFunction = TimeAfterArbiterComposingAbi.find(
-  (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
-);
-const timeAfterArbiterNonComposingDecodeDemandFunction = TimeAfterArbiterNonComposingAbi.find(
-  (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
-);
-const timeBeforeArbiterComposingDecodeDemandFunction = TimeBeforeArbiterComposingAbi.find(
-  (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
-);
-const timeBeforeArbiterNonComposingDecodeDemandFunction = TimeBeforeArbiterNonComposingAbi.find(
-  (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
-);
-const timeEqualArbiterComposingDecodeDemandFunction = TimeEqualArbiterComposingAbi.find(
-  (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
-);
-const timeEqualArbiterNonComposingDecodeDemandFunction = TimeEqualArbiterNonComposingAbi.find(
-  (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
-);
-const expirationTimeAfterArbiterComposingDecodeDemandFunction = ExpirationTimeAfterArbiterComposingAbi.find(
-  (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
-);
-const expirationTimeAfterArbiterNonComposingDecodeDemandFunction = ExpirationTimeAfterArbiterNonComposingAbi.find(
-  (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
-);
-const expirationTimeBeforeArbiterComposingDecodeDemandFunction = ExpirationTimeBeforeArbiterComposingAbi.find(
-  (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
-);
-const expirationTimeBeforeArbiterNonComposingDecodeDemandFunction = ExpirationTimeBeforeArbiterNonComposingAbi.find(
-  (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
-);
-const expirationTimeEqualArbiterComposingDecodeDemandFunction = ExpirationTimeEqualArbiterComposingAbi.find(
-  (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
-);
-const expirationTimeEqualArbiterNonComposingDecodeDemandFunction = ExpirationTimeEqualArbiterNonComposingAbi.find(
-  (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
-);
-const recipientArbiterComposingDecodeDemandFunction = RecipientArbiterComposingAbi.find(
-  (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
-);
-const recipientArbiterNonComposingDecodeDemandFunction = RecipientArbiterNonComposingAbi.find(
-  (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
-);
-const refUidArbiterComposingDecodeDemandFunction = RefUidArbiterComposingAbi.find(
-  (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
-);
-const refUidArbiterNonComposingDecodeDemandFunction = RefUidArbiterNonComposingAbi.find(
-  (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
-);
-const revocableArbiterComposingDecodeDemandFunction = RevocableArbiterComposingAbi.find(
-  (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
-);
-const revocableArbiterNonComposingDecodeDemandFunction = RevocableArbiterNonComposingAbi.find(
-  (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
-);
-const schemaArbiterComposingDecodeDemandFunction = SchemaArbiterComposingAbi.find(
-  (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
-);
-const schemaArbiterNonComposingDecodeDemandFunction = SchemaArbiterNonComposingAbi.find(
-  (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
-);
-const uidArbiterComposingDecodeDemandFunction = UidArbiterComposingAbi.find(
-  (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
-);
-const uidArbiterNonComposingDecodeDemandFunction = UidArbiterNonComposingAbi.find(
-  (item: any) => item.type === 'function' && item.name === 'decodeDemandData'
-);
+const attesterArbiterComposingDecodeDemandFunction = getAbiItem({
+  abi: AttesterArbiterComposingAbi,
+  name: 'decodeDemandData'
+});
+const attesterArbiterNonComposingDecodeDemandFunction = getAbiItem({
+  abi: AttesterArbiterNonComposingAbi,
+  name: 'decodeDemandData'
+});
+const timeAfterArbiterComposingDecodeDemandFunction = getAbiItem({
+  abi: TimeAfterArbiterComposingAbi,
+  name: 'decodeDemandData'
+});
+const timeAfterArbiterNonComposingDecodeDemandFunction = getAbiItem({
+  abi: TimeAfterArbiterNonComposingAbi,
+  name: 'decodeDemandData'
+});
+const timeBeforeArbiterComposingDecodeDemandFunction = getAbiItem({
+  abi: TimeBeforeArbiterComposingAbi,
+  name: 'decodeDemandData'
+});
+const timeBeforeArbiterNonComposingDecodeDemandFunction = getAbiItem({
+  abi: TimeBeforeArbiterNonComposingAbi,
+  name: 'decodeDemandData'
+});
+const timeEqualArbiterComposingDecodeDemandFunction = getAbiItem({
+  abi: TimeEqualArbiterComposingAbi,
+  name: 'decodeDemandData'
+});
+const timeEqualArbiterNonComposingDecodeDemandFunction = getAbiItem({
+  abi: TimeEqualArbiterNonComposingAbi,
+  name: 'decodeDemandData'
+});
+const expirationTimeAfterArbiterComposingDecodeDemandFunction = getAbiItem({
+  abi: ExpirationTimeAfterArbiterComposingAbi,
+  name: 'decodeDemandData'
+});
+const expirationTimeAfterArbiterNonComposingDecodeDemandFunction = getAbiItem({
+  abi: ExpirationTimeAfterArbiterNonComposingAbi,
+  name: 'decodeDemandData'
+});
+const expirationTimeBeforeArbiterComposingDecodeDemandFunction = getAbiItem({
+  abi: ExpirationTimeBeforeArbiterComposingAbi,
+  name: 'decodeDemandData'
+});
+const expirationTimeBeforeArbiterNonComposingDecodeDemandFunction = getAbiItem({
+  abi: ExpirationTimeBeforeArbiterNonComposingAbi,
+  name: 'decodeDemandData'
+});
+const expirationTimeEqualArbiterComposingDecodeDemandFunction = getAbiItem({
+  abi: ExpirationTimeEqualArbiterComposingAbi,
+  name: 'decodeDemandData'
+});
+const expirationTimeEqualArbiterNonComposingDecodeDemandFunction = getAbiItem({
+  abi: ExpirationTimeEqualArbiterNonComposingAbi,
+  name: 'decodeDemandData'
+});
+const recipientArbiterComposingDecodeDemandFunction = getAbiItem({
+  abi: RecipientArbiterComposingAbi,
+  name: 'decodeDemandData'
+});
+const recipientArbiterNonComposingDecodeDemandFunction = getAbiItem({
+  abi: RecipientArbiterNonComposingAbi,
+  name: 'decodeDemandData'
+});
+const refUidArbiterComposingDecodeDemandFunction = getAbiItem({
+  abi: RefUidArbiterComposingAbi,
+  name: 'decodeDemandData'
+});
+const refUidArbiterNonComposingDecodeDemandFunction = getAbiItem({
+  abi: RefUidArbiterNonComposingAbi,
+  name: 'decodeDemandData'
+});
+const revocableArbiterComposingDecodeDemandFunction = getAbiItem({
+  abi: RevocableArbiterComposingAbi,
+  name: 'decodeDemandData'
+});
+const revocableArbiterNonComposingDecodeDemandFunction = getAbiItem({
+  abi: RevocableArbiterNonComposingAbi,
+  name: 'decodeDemandData'
+});
+const schemaArbiterComposingDecodeDemandFunction = getAbiItem({
+  abi: SchemaArbiterComposingAbi,
+  name: 'decodeDemandData'
+});
+const schemaArbiterNonComposingDecodeDemandFunction = getAbiItem({
+  abi: SchemaArbiterNonComposingAbi,
+  name: 'decodeDemandData'
+});
+const uidArbiterComposingDecodeDemandFunction = getAbiItem({
+  abi: UidArbiterComposingAbi,
+  name: 'decodeDemandData'
+});
+const uidArbiterNonComposingDecodeDemandFunction = getAbiItem({
+  abi: UidArbiterNonComposingAbi,
+  name: 'decodeDemandData'
+});
 
 // Extract the DemandData struct types from the function outputs
-const attesterArbiterComposingDemandDataType = (attesterArbiterComposingDecodeDemandFunction as { outputs: readonly any[] } | undefined)?.outputs?.[0];
-const attesterArbiterNonComposingDemandDataType = (attesterArbiterNonComposingDecodeDemandFunction as { outputs: readonly any[] } | undefined)?.outputs?.[0];
-const timeAfterArbiterComposingDemandDataType = (timeAfterArbiterComposingDecodeDemandFunction as { outputs: readonly any[] } | undefined)?.outputs?.[0];
-const timeAfterArbiterNonComposingDemandDataType = (timeAfterArbiterNonComposingDecodeDemandFunction as { outputs: readonly any[] } | undefined)?.outputs?.[0];
-const timeBeforeArbiterComposingDemandDataType = (timeBeforeArbiterComposingDecodeDemandFunction as { outputs: readonly any[] } | undefined)?.outputs?.[0];
-const timeBeforeArbiterNonComposingDemandDataType = (timeBeforeArbiterNonComposingDecodeDemandFunction as { outputs: readonly any[] } | undefined)?.outputs?.[0];
-const timeEqualArbiterComposingDemandDataType = (timeEqualArbiterComposingDecodeDemandFunction as { outputs: readonly any[] } | undefined)?.outputs?.[0];
-const timeEqualArbiterNonComposingDemandDataType = (timeEqualArbiterNonComposingDecodeDemandFunction as { outputs: readonly any[] } | undefined)?.outputs?.[0];
-const expirationTimeAfterArbiterComposingDemandDataType = (expirationTimeAfterArbiterComposingDecodeDemandFunction as { outputs: readonly any[] } | undefined)?.outputs?.[0];
-const expirationTimeAfterArbiterNonComposingDemandDataType = (expirationTimeAfterArbiterNonComposingDecodeDemandFunction as { outputs: readonly any[] } | undefined)?.outputs?.[0];
-const expirationTimeBeforeArbiterComposingDemandDataType = (expirationTimeBeforeArbiterComposingDecodeDemandFunction as { outputs: readonly any[] } | undefined)?.outputs?.[0];
-const expirationTimeBeforeArbiterNonComposingDemandDataType = (expirationTimeBeforeArbiterNonComposingDecodeDemandFunction as { outputs: readonly any[] } | undefined)?.outputs?.[0];
-const expirationTimeEqualArbiterComposingDemandDataType = (expirationTimeEqualArbiterComposingDecodeDemandFunction as { outputs: readonly any[] } | undefined)?.outputs?.[0];
-const expirationTimeEqualArbiterNonComposingDemandDataType = (expirationTimeEqualArbiterNonComposingDecodeDemandFunction as { outputs: readonly any[] } | undefined)?.outputs?.[0];
-const recipientArbiterComposingDemandDataType = (recipientArbiterComposingDecodeDemandFunction as { outputs: readonly any[] } | undefined)?.outputs?.[0];
-const recipientArbiterNonComposingDemandDataType = (recipientArbiterNonComposingDecodeDemandFunction as { outputs: readonly any[] } | undefined)?.outputs?.[0];
-const refUidArbiterComposingDemandDataType = (refUidArbiterComposingDecodeDemandFunction as { outputs: readonly any[] } | undefined)?.outputs?.[0];
-const refUidArbiterNonComposingDemandDataType = (refUidArbiterNonComposingDecodeDemandFunction as { outputs: readonly any[] } | undefined)?.outputs?.[0];
-const revocableArbiterComposingDemandDataType = (revocableArbiterComposingDecodeDemandFunction as { outputs: readonly any[] } | undefined)?.outputs?.[0];
-const revocableArbiterNonComposingDemandDataType = (revocableArbiterNonComposingDecodeDemandFunction as { outputs: readonly any[] } | undefined)?.outputs?.[0];
-const schemaArbiterComposingDemandDataType = (schemaArbiterComposingDecodeDemandFunction as { outputs: readonly any[] } | undefined)?.outputs?.[0];
-const schemaArbiterNonComposingDemandDataType = (schemaArbiterNonComposingDecodeDemandFunction as { outputs: readonly any[] } | undefined)?.outputs?.[0];
-const uidArbiterComposingDemandDataType = (uidArbiterComposingDecodeDemandFunction as { outputs: readonly any[] } | undefined)?.outputs?.[0];
-const uidArbiterNonComposingDemandDataType = (uidArbiterNonComposingDecodeDemandFunction as { outputs: readonly any[] } | undefined)?.outputs?.[0];
+const attesterArbiterComposingDemandDataType = attesterArbiterComposingDecodeDemandFunction.outputs[0];
+const attesterArbiterNonComposingDemandDataType = attesterArbiterNonComposingDecodeDemandFunction.outputs[0];
+const timeAfterArbiterComposingDemandDataType = timeAfterArbiterComposingDecodeDemandFunction.outputs[0];
+const timeAfterArbiterNonComposingDemandDataType = timeAfterArbiterNonComposingDecodeDemandFunction.outputs[0];
+const timeBeforeArbiterComposingDemandDataType = timeBeforeArbiterComposingDecodeDemandFunction.outputs[0];
+const timeBeforeArbiterNonComposingDemandDataType = timeBeforeArbiterNonComposingDecodeDemandFunction.outputs[0];
+const timeEqualArbiterComposingDemandDataType = timeEqualArbiterComposingDecodeDemandFunction.outputs[0];
+const timeEqualArbiterNonComposingDemandDataType = timeEqualArbiterNonComposingDecodeDemandFunction.outputs[0];
+const expirationTimeAfterArbiterComposingDemandDataType = expirationTimeAfterArbiterComposingDecodeDemandFunction.outputs[0];
+const expirationTimeAfterArbiterNonComposingDemandDataType = expirationTimeAfterArbiterNonComposingDecodeDemandFunction.outputs[0];
+const expirationTimeBeforeArbiterComposingDemandDataType = expirationTimeBeforeArbiterComposingDecodeDemandFunction.outputs[0];
+const expirationTimeBeforeArbiterNonComposingDemandDataType = expirationTimeBeforeArbiterNonComposingDecodeDemandFunction.outputs[0];
+const expirationTimeEqualArbiterComposingDemandDataType = expirationTimeEqualArbiterComposingDecodeDemandFunction.outputs[0];
+const expirationTimeEqualArbiterNonComposingDemandDataType = expirationTimeEqualArbiterNonComposingDecodeDemandFunction.outputs[0];
+const recipientArbiterComposingDemandDataType = recipientArbiterComposingDecodeDemandFunction.outputs[0];
+const recipientArbiterNonComposingDemandDataType = recipientArbiterNonComposingDecodeDemandFunction.outputs[0];
+const refUidArbiterComposingDemandDataType = refUidArbiterComposingDecodeDemandFunction.outputs[0];
+const refUidArbiterNonComposingDemandDataType = refUidArbiterNonComposingDecodeDemandFunction.outputs[0];
+const revocableArbiterComposingDemandDataType = revocableArbiterComposingDecodeDemandFunction.outputs[0];
+const revocableArbiterNonComposingDemandDataType = revocableArbiterNonComposingDecodeDemandFunction.outputs[0];
+const schemaArbiterComposingDemandDataType = schemaArbiterComposingDecodeDemandFunction.outputs[0];
+const schemaArbiterNonComposingDemandDataType = schemaArbiterNonComposingDecodeDemandFunction.outputs[0];
+const uidArbiterComposingDemandDataType = uidArbiterComposingDecodeDemandFunction.outputs[0];
+const uidArbiterNonComposingDemandDataType = uidArbiterNonComposingDecodeDemandFunction.outputs[0];
+
+/**
+ * Attestation Properties Arbiters Client
+ * 
 
 // Ensure ABI extraction succeeded - fail fast if contract JSONs are malformed
 if (!attesterArbiterComposingDemandDataType) {

--- a/src/clients/erc1155.ts
+++ b/src/clients/erc1155.ts
@@ -20,27 +20,22 @@ import { abi as erc1155Abi } from "../contracts/IERC1155";
 import {
   decodeAbiParameters,
   encodeAbiParameters,
+  getAbiItem,
 } from "viem";
 
 // Extract ABI types at module initialization with fail-fast error handling
-const erc1155EscrowDecodeFunction = erc1155EscrowAbi.abi.find(
-  (item: any) => item.type === 'function' && item.name === 'decodeObligationData'
-);
-const erc1155PaymentDecodeFunction = erc1155PaymentAbi.abi.find(
-  (item: any) => item.type === 'function' && item.name === 'decodeObligationData'
-);
+const erc1155EscrowDecodeFunction = getAbiItem({
+  abi: erc1155EscrowAbi.abi,
+  name: 'decodeObligationData'
+});
+const erc1155PaymentDecodeFunction = getAbiItem({
+  abi: erc1155PaymentAbi.abi,
+  name: 'decodeObligationData'
+});
 
 // Extract the ObligationData struct types from the function outputs
-const erc1155EscrowObligationDataType = (erc1155EscrowDecodeFunction as { outputs: readonly any[] } | undefined)?.outputs?.[0];
-const erc1155PaymentObligationDataType = (erc1155PaymentDecodeFunction as { outputs: readonly any[] } | undefined)?.outputs?.[0];
-
-// Ensure ABI extraction succeeded - fail fast if contract JSONs are malformed
-if (!erc1155EscrowObligationDataType) {
-  throw new Error('Failed to extract ABI type from ERC1155EscrowObligation contract JSON. The contract definition may be missing or malformed.');
-}
-if (!erc1155PaymentObligationDataType) {
-  throw new Error('Failed to extract ABI type from ERC1155PaymentObligation contract JSON. The contract definition may be missing or malformed.');
-}
+const erc1155EscrowObligationDataType = erc1155EscrowDecodeFunction.outputs[0];
+const erc1155PaymentObligationDataType = erc1155PaymentDecodeFunction.outputs[0];
 
 export const makeErc1155Client = (
   viemClient: ViemClient,

--- a/src/clients/erc20.ts
+++ b/src/clients/erc20.ts
@@ -16,6 +16,7 @@ import type {
 import {
   decodeAbiParameters,
   encodeAbiParameters,
+  getAbiItem,
   hexToNumber,
   parseAbiParameter,
   slice,
@@ -31,38 +32,28 @@ import { abi as easAbi } from "../contracts/IEAS";
 import type { ApprovalPurpose } from "../types";
 
 // Extract ObligationData struct ABIs from contract ABIs at module initialization
-const erc20EscrowDoObligationFunction = erc20EscrowAbi.abi.find(
-  (item: any) => item.type === 'function' && item.name === 'doObligation'
-);
-const erc20PaymentDoObligationFunction = erc20PaymentAbi.abi.find(
-  (item: any) => item.type === 'function' && item.name === 'doObligation'
-);
-const erc721EscrowDoObligationFunction = erc721EscrowAbi.abi.find(
-  (item: any) => item.type === 'function' && item.name === 'doObligation'
-);
-const tokenBundlePaymentDecodeFunction = tokenBundlePaymentAbi.abi.find(
-  (item: any) => item.type === 'function' && item.name === 'decodeObligationData'
-);
+const erc20EscrowDoObligationFunction = getAbiItem({
+  abi: erc20EscrowAbi.abi,
+  name: 'doObligation'
+});
+const erc20PaymentDoObligationFunction = getAbiItem({
+  abi: erc20PaymentAbi.abi,
+  name: 'doObligation'
+});
+const erc721EscrowDoObligationFunction = getAbiItem({
+  abi: erc721EscrowAbi.abi,
+  name: 'doObligation'
+});
+const tokenBundlePaymentDecodeFunction = getAbiItem({
+  abi: tokenBundlePaymentAbi.abi,
+  name: 'decodeObligationData'
+});
 
 // Extract the ObligationData struct types from the function inputs
-const erc20EscrowObligationDataType = (erc20EscrowDoObligationFunction as { inputs: readonly any[] } | undefined)?.inputs?.[0];
-const erc20PaymentObligationDataType = (erc20PaymentDoObligationFunction as { inputs: readonly any[] } | undefined)?.inputs?.[0];
-const erc721EscrowObligationDataType = (erc721EscrowDoObligationFunction as { inputs: readonly any[] } | undefined)?.inputs?.[0];
-const tokenBundlePaymentObligationDataType = (tokenBundlePaymentDecodeFunction as { outputs: readonly any[] } | undefined)?.outputs?.[0];
-
-// Ensure ABI extraction succeeded - fail fast if contract JSONs are malformed
-if (!erc20EscrowObligationDataType) {
-  throw new Error('Failed to extract ABI type from ERC20EscrowObligation contract JSON. The contract definition may be missing or malformed.');
-}
-if (!erc20PaymentObligationDataType) {
-  throw new Error('Failed to extract ABI type from ERC20PaymentObligation contract JSON. The contract definition may be missing or malformed.');
-}
-if (!erc721EscrowObligationDataType) {
-  throw new Error('Failed to extract ABI type from ERC721EscrowObligation contract JSON. The contract definition may be missing or malformed.');
-}
-if (!tokenBundlePaymentObligationDataType) {
-  throw new Error('Failed to extract ABI type from TokenBundlePaymentObligation contract JSON. The contract definition may be missing or malformed.');
-}
+const erc20EscrowObligationDataType = erc20EscrowDoObligationFunction.inputs[0];
+const erc20PaymentObligationDataType = erc20PaymentDoObligationFunction.inputs[0];
+const erc721EscrowObligationDataType = erc721EscrowDoObligationFunction.inputs[0];
+const tokenBundlePaymentObligationDataType = tokenBundlePaymentDecodeFunction.outputs[0];
 
 export const makeErc20Client = (
   viemClient: ViemClient,

--- a/src/clients/erc721.ts
+++ b/src/clients/erc721.ts
@@ -20,27 +20,22 @@ import { abi as erc721Abi } from "../contracts/IERC721";
 import {
   decodeAbiParameters,
   encodeAbiParameters,
+  getAbiItem,
 } from "viem";
 
 // Extract ABI types at module initialization with fail-fast error handling
-const erc721EscrowDecodeFunction = erc721EscrowAbi.abi.find(
-  (item: any) => item.type === 'function' && item.name === 'decodeObligationData'
-);
-const erc721PaymentDecodeFunction = erc721PaymentAbi.abi.find(
-  (item: any) => item.type === 'function' && item.name === 'decodeObligationData'
-);
+const erc721EscrowDecodeFunction = getAbiItem({
+  abi: erc721EscrowAbi.abi,
+  name: 'decodeObligationData'
+});
+const erc721PaymentDecodeFunction = getAbiItem({
+  abi: erc721PaymentAbi.abi,
+  name: 'decodeObligationData'
+});
 
 // Extract the ObligationData struct types from the function outputs
-const erc721EscrowObligationDataType = (erc721EscrowDecodeFunction as { outputs: readonly any[] } | undefined)?.outputs?.[0];
-const erc721PaymentObligationDataType = (erc721PaymentDecodeFunction as { outputs: readonly any[] } | undefined)?.outputs?.[0];
-
-// Ensure ABI extraction succeeded - fail fast if contract JSONs are malformed
-if (!erc721EscrowObligationDataType) {
-  throw new Error('Failed to extract ABI type from ERC721EscrowObligation contract JSON. The contract definition may be missing or malformed.');
-}
-if (!erc721PaymentObligationDataType) {
-  throw new Error('Failed to extract ABI type from ERC721PaymentObligation contract JSON. The contract definition may be missing or malformed.');
-}
+const erc721EscrowObligationDataType = erc721EscrowDecodeFunction.outputs[0];
+const erc721PaymentObligationDataType = erc721PaymentDecodeFunction.outputs[0];
 
 export const makeErc721Client = (
   viemClient: ViemClient,

--- a/src/clients/generalArbiters.ts
+++ b/src/clients/generalArbiters.ts
@@ -1,6 +1,7 @@
 import {
   decodeAbiParameters,
   encodeAbiParameters,
+  getAbiItem,
   parseAbiItem,
 } from "viem";
 import type { ViemClient } from "../utils";
@@ -13,41 +14,28 @@ import { abi as TrustedPartyArbiterAbi } from "../contracts/TrustedPartyArbiter"
 import { abi as SpecificAttestationArbiterAbi } from "../contracts/SpecificAttestationArbiter";
 
 // Extract DemandData struct ABI from contract ABIs at module initialization
-const intrinsicsArbiter2DecodeDemandFunction = IntrinsicsArbiter2Abi.abi.find(
-  (item) => item.type === 'function' && item.name === 'decodeDemandData'
-);
-const trustedPartyArbiterDecodeDemandFunction = TrustedPartyArbiterAbi.abi.find(
-  (item) => item.type === 'function' && item.name === 'decodeDemandData'
-);
-const specificAttestationArbiterDecodeDemandFunction = SpecificAttestationArbiterAbi.abi.find(
-  (item) => item.type === 'function' && item.name === 'decodeDemandData'
-);
-const trustedOracleArbiterDecodeDemandFunction = trustedOracleArbiterAbi.abi.find(
-  (item) => item.type === 'function' && item.name === 'decodeDemandData'
-);
+const intrinsicsArbiter2DecodeDemandFunction = getAbiItem({
+  abi: IntrinsicsArbiter2Abi.abi,
+  name: 'decodeDemandData'
+});
+const trustedPartyArbiterDecodeDemandFunction = getAbiItem({
+  abi: TrustedPartyArbiterAbi.abi,
+  name: 'decodeDemandData'
+});
+const specificAttestationArbiterDecodeDemandFunction = getAbiItem({
+  abi: SpecificAttestationArbiterAbi.abi,
+  name: 'decodeDemandData'
+});
+const trustedOracleArbiterDecodeDemandFunction = getAbiItem({
+  abi: trustedOracleArbiterAbi.abi,
+  name: 'decodeDemandData'
+});
 
 // Extract the DemandData struct types from the function outputs
-const intrinsicsArbiter2DemandDataType = intrinsicsArbiter2DecodeDemandFunction?.outputs?.[0];
-const trustedPartyArbiterDemandDataType = trustedPartyArbiterDecodeDemandFunction?.outputs?.[0];
-const specificAttestationArbiterDemandDataType = specificAttestationArbiterDecodeDemandFunction?.outputs?.[0];
-const trustedOracleArbiterDemandDataType = trustedOracleArbiterDecodeDemandFunction?.outputs?.[0];
-
-// Ensure ABI extraction succeeded - fail fast if contract JSONs are malformed
-if (!intrinsicsArbiter2DemandDataType) {
-  throw new Error('Failed to extract ABI type from IntrinsicsArbiter2 contract JSON. The contract definition may be missing or malformed.');
-}
-
-if (!trustedPartyArbiterDemandDataType) {
-  throw new Error('Failed to extract ABI type from TrustedPartyArbiter contract JSON. The contract definition may be missing or malformed.');
-}
-
-if (!specificAttestationArbiterDemandDataType) {
-  throw new Error('Failed to extract ABI type from SpecificAttestationArbiter contract JSON. The contract definition may be missing or malformed.');
-}
-
-if (!trustedOracleArbiterDemandDataType) {
-  throw new Error('Failed to extract ABI type from TrustedOracleArbiter contract JSON. The contract definition may be missing or malformed.');
-}
+const intrinsicsArbiter2DemandDataType = intrinsicsArbiter2DecodeDemandFunction.outputs[0];
+const trustedPartyArbiterDemandDataType = trustedPartyArbiterDecodeDemandFunction.outputs[0];
+const specificAttestationArbiterDemandDataType = specificAttestationArbiterDecodeDemandFunction.outputs[0];
+const trustedOracleArbiterDemandDataType = trustedOracleArbiterDecodeDemandFunction.outputs[0];
 
 /**
  * General Arbiters Client

--- a/src/clients/logicalArbiters.ts
+++ b/src/clients/logicalArbiters.ts
@@ -1,6 +1,7 @@
 import {
   decodeAbiParameters,
   encodeAbiParameters,
+  getAbiItem,
 } from "viem";
 import type { ViemClient } from "../utils";
 import type { ChainAddresses } from "../types";
@@ -8,25 +9,18 @@ import { abi as AllArbiterAbi } from "../contracts/AllArbiter";
 import { abi as AnyArbiterAbi } from "../contracts/AnyArbiter";
 
 // Extract DemandData struct ABI from contract ABIs at module initialization
-const anyArbiterDecodeDemandFunction = AnyArbiterAbi.abi.find(
-  (item) => item.type === 'function' && item.name === 'decodeDemandData'
-);
-const allArbiterDecodeDemandFunction = AllArbiterAbi.abi.find(
-  (item) => item.type === 'function' && item.name === 'decodeDemandData'
-);
+const anyArbiterDecodeDemandFunction = getAbiItem({
+  abi: AnyArbiterAbi.abi,
+  name: 'decodeDemandData'
+});
+const allArbiterDecodeDemandFunction = getAbiItem({
+  abi: AllArbiterAbi.abi,
+  name: 'decodeDemandData'
+});
 
 // Extract the DemandData struct types from the function outputs
-const anyDemandDataType = anyArbiterDecodeDemandFunction?.outputs?.[0];
-const allDemandDataType = allArbiterDecodeDemandFunction?.outputs?.[0];
-
-// Ensure ABI extraction succeeded - fail fast if contract JSONs are malformed
-if (!anyDemandDataType) {
-  throw new Error('Failed to extract ABI type from AnyArbiter contract JSON. The contract definition may be missing or malformed.');
-}
-
-if (!allDemandDataType) {
-  throw new Error('Failed to extract ABI type from AllArbiter contract JSON. The contract definition may be missing or malformed.');
-}
+const anyDemandDataType = anyArbiterDecodeDemandFunction.outputs[0];
+const allDemandDataType = allArbiterDecodeDemandFunction.outputs[0];
 
 /**
  * Logical Arbiters Client

--- a/src/clients/stringObligation.ts
+++ b/src/clients/stringObligation.ts
@@ -1,6 +1,7 @@
 import {
   decodeAbiParameters,
   encodeAbiParameters,
+  getAbiItem,
 } from "viem";
 import type { ViemClient } from "../utils";
 import { getAttestation, getAttestedEventFromTxHash } from "../utils";
@@ -11,17 +12,13 @@ import type { z, ZodTypeDef, SafeParseReturnType } from "zod";
 import type { Type } from "arktype";
 
 // Extract ABI type at module initialization with fail-fast error handling
-const stringObligationDecodeFunction = stringObligationAbi.abi.find(
-  (item: any) => item.type === 'function' && item.name === 'decodeObligationData'
-);
+const stringObligationDecodeFunction = getAbiItem({
+  abi: stringObligationAbi.abi,
+  name: 'decodeObligationData'
+});
 
 // Extract the ObligationData struct type from the function output
-const stringObligationDataType = (stringObligationDecodeFunction as { outputs: readonly any[] } | undefined)?.outputs?.[0];
-
-// Ensure ABI extraction succeeded - fail if JSONs are malformed
-if (!stringObligationDataType) {
-  throw new Error('Failed to extract ABI type from StringObligation contract JSON. The contract definition may be missing or malformed.');
-}
+const stringObligationDataType = stringObligationDecodeFunction.outputs[0];
 
 // Type helper for Zod parse functions return types
 type ZodParseReturnType<

--- a/src/clients/tokenBundle.ts
+++ b/src/clients/tokenBundle.ts
@@ -15,6 +15,7 @@ import { abi as erc1155Abi } from "../contracts/IERC1155";
 import {
   decodeAbiParameters,
   encodeAbiParameters,
+  getAbiItem,
 } from "viem";
 
 export const makeTokenBundleClient = (
@@ -22,21 +23,15 @@ export const makeTokenBundleClient = (
   addresses: ChainAddresses,
 ) => {
   // Extract ABI types for encoding/decoding from contract ABIs
-  const escrowObligationDataType = tokenBundleEscrowAbi.abi.find(
-    (item) => item.type === "function" && item.name === "decodeObligationData"
-  )?.outputs?.[0];
+  const escrowObligationDataType = getAbiItem({
+    abi: tokenBundleEscrowAbi.abi,
+    name: "decodeObligationData"
+  }).outputs[0];
 
-  if (!escrowObligationDataType) {
-    throw new Error("TokenBundleEscrowObligation contract ABI is missing decodeObligationData function outputs");
-  }
-
-  const paymentObligationDataType = tokenBundlePaymentAbi.abi.find(
-    (item) => item.type === "function" && item.name === "decodeObligationData"
-  )?.outputs?.[0];
-
-  if (!paymentObligationDataType) {
-    throw new Error("TokenBundlePaymentObligation contract ABI is missing decodeObligationData function outputs");
-  }
+  const paymentObligationDataType = getAbiItem({
+    abi: tokenBundlePaymentAbi.abi,
+    name: "decodeObligationData"
+  }).outputs[0];
 
   /**
    * Encodes TokenBundleEscrowObligation.ObligationData to bytes using raw parameters.


### PR DESCRIPTION
Update to use viem.getAbiItem() instead of manual type cast or finding the string when encoding / decoding items from contracts.